### PR TITLE
Stubbed out MemorySize and MemoryGrow instructions

### DIFF
--- a/src/codegen/block.rs
+++ b/src/codegen/block.rs
@@ -1020,6 +1020,13 @@ pub fn compile_block<'a, 'b>(
                 let v = stack.pop().unwrap();
                 store_val::<f64>(m_ctx, b, &mut stack, offset, v);
             }
+
+            Instruction::MemorySize => {
+                // FIXME: needs implementation?
+            }
+            Instruction::MemoryGrow => {
+                // FIXME: needs implementation?
+            }
         }
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -412,6 +412,9 @@ pub enum Instruction {
 
     F64Load { flags: u32, offset: u32 },
     F64Store { flags: u32, offset: u32 },
+
+    MemorySize,
+    MemoryGrow,
 }
 
 impl<'a> From<&'a Operator<'a>> for Instruction {
@@ -722,6 +725,8 @@ impl<'a> From<&'a Operator<'a>> for Instruction {
                 flags: memarg.flags,
                 offset: memarg.offset,
             },
+            Operator::MemorySize { reserved: _ } => Instruction::MemorySize,
+            Operator::MemoryGrow { reserved: _ } => Instruction::MemoryGrow,
 
             ref e => unimplemented!("{:?}", e),
         }
@@ -922,7 +927,12 @@ impl WasmModule {
                             mutable: global_ty.mutable,
                         });
                     }
-                    e => panic!("Have not implemented import section entry type {:?}", e),
+                    ImportSectionEntryType::Memory(memory_ty) => {
+                        self.memories.push(*memory_ty);
+                    }
+                    ImportSectionEntryType::Table(table_ty) => {
+                        self.tables.push(*table_ty);
+                    }
                 }
                 ProcessState::ImportSection
             }


### PR DESCRIPTION
This is required to be able to compile WASI-SDK. I'm not sure what the correct behavior should be. Just having these as noops seems to work but I'm not sure that's expected. Maybe they should emit a function call to the expand_memory function?

Also I added tracking for the memory and table import sections, those are required if compiling incrementally.