### PR TITLE
Moved Cortex-M specific LLVM attrs behind features=cortex-m-attrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,14 @@ edition = "2018"
 
 [dependencies]
 flexi_logger = "0.14.4"
-llvm-sys = "90.0.0"
-llvm-alt = { git = "https://github.com/Others/llvm-rs.git"}
+llvm-sys = { version = "90.0.0", optional = true }
+llvm-alt = { git = "https://github.com/Others/llvm-rs.git" }
 log = "0.4.8"
 structopt = "0.3.2"
 wasmparser = "0.39.2"
+
+[features]
+cortex-m-attrs = ['llvm-sys']
 
 [profile.release]
 debug = true


### PR DESCRIPTION
This moves the Cortex-M-specific attributes behind the feature flag "cortex-m-attrs". Happen to change it if you prefer a different name.

Note the appropriate checks are already in place so that the attributes are only added if the target is "thumbv7em-none-unknown-eabi", but there is a separate issue with the dual dependency on llvm-sys that occurs at link-time. I've moved the dual-dependency behind the feature flag to avoid this.

Captured the info I know here: https://github.com/gwsystems/aWsm/issues/9