### PR TITLE
Fix testing on Ubuntu 19.10

### DIFF
--- a/code_benches/run.py
+++ b/code_benches/run.py
@@ -113,10 +113,10 @@ programs = [
     Program("custom_sqlite", [], 2 ** 15, custom_arguments=["-DSQLITE_MUTEX_NOOP", "-ldl"]),
 
     # == Apps ==
-    # Program("app_nn", [], 2 ** 14, custom_arguments=["-std=c99", "-Wno-unknown-attributes", "-DARM_MATH_CM3", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/DSP/Include", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/Core/Include", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/NN/Include"]),
-#    Program("app_pid", ["-std=c++11", "-Wall"], 2 ** 8, custom_arguments=[], is_cpp=True),
-#    Program("app_tiny_ekf", ["-std=c++11", "-Wall"], 2 ** 14, custom_arguments=[], is_cpp=True),
-#    Program("app_tinycrypt", [], 2 ** 15 + 2**14, custom_arguments=[ "-Wall", "-Wpedantic", "-Wno-gnu-zero-variadic-macro-arguments", "-std=c11", "-I/Users/peachg/Projects/silverfish/code_benches/app_tinycrypt/", "-DENABLE_TESTS", "-I."]),
+    #Program("app_nn", [], 2 ** 14, custom_arguments=["-std=c99", "-Wno-unknown-attributes", "-DARM_MATH_CM3", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/DSP/Include", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/Core/Include", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/NN/Include"]),
+    Program("app_pid", ["-std=c++11", "-Wall"], 2 ** 8, custom_arguments=[], is_cpp=True),
+    Program("app_tiny_ekf", ["-std=c++11", "-Wall"], 2 ** 14, custom_arguments=[], is_cpp=True),
+    Program("app_tinycrypt", [], 2 ** 15 + 2**14, custom_arguments=[ "-Wall", "-Wpedantic", "-Wno-gnu-zero-variadic-macro-arguments", "-std=c11", "-DENABLE_TESTS", "-I."]),
     # Program("app_v9", [], 2 ** 18, custom_arguments=[], do_lto=False),
 
     # == MiBench ==

--- a/code_benches/run.py
+++ b/code_benches/run.py
@@ -177,11 +177,14 @@ def compile_to_executable(program):
     if ENABLE_DEBUG_SYMBOLS:
         opt += " -g"
     if program.is_cpp:
-        sp.check_call("clang++ {} -lm {} {} -o bin/{}".format(program.custom_arguments, opt, program.sources(), program.name), shell=True, cwd=program.name)
+        clang = "clang++"
     else:
-        sp.check_call("clang {} -lm {} {} -o bin/{}".format(program.custom_arguments, opt, program.sources(), program.name), shell=True, cwd=program.name)
-        # sp.check_call("clang {} -lm {} *.c -o bin/{}".format(program.custom_arguments, opt, program.name), shell=True, cwd=program.name)
+        clang = "clang"
 
+    command = "{clang} {args} -lm {opt} {sources} -o bin/{pname}" \
+        .format(clang=clang, args=program.custom_arguments, opt=opt, sources=program.sources(), pname=program.name)
+    print(command)
+    sp.check_call(command, shell=True, cwd=program.name)
 
 # Compile the C code in `program`'s directory into WASM
 def compile_to_wasm(program):

--- a/code_benches/run.py
+++ b/code_benches/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import csv
 import os
 import subprocess as sp
@@ -15,13 +17,19 @@ SILVERFISH_TARGET = None
 # CSV file name
 CSV_NAME = "benchmarks.csv"
 
+# Make sure we're in the code_benches directory
+if os.path.dirname(sys.argv[0]):
+    os.chdir(os.path.dirname(sys.argv[0]))
 # Absolute path to the `code_benches` directory
 BENCH_ROOT = os.getcwd()
 # Absolute path to the `silverfish` directory
 ROOT_PATH = os.path.dirname(BENCH_ROOT)
 
 RUNTIME_PATH = ROOT_PATH + "/runtime"
-SILVERFISH_PATH = ROOT_PATH + "/target/release/silverfish"
+if "--release" in sys.argv:
+    SILVERFISH_PATH = ROOT_PATH + "/target/release/silverfish"
+else:
+    SILVERFISH_PATH = ROOT_PATH + "/target/debug/silverfish"
 
 WASMCEPTION_PATH = ROOT_PATH + "/wasmception"
 
@@ -92,9 +100,9 @@ programs = [
 
     # == Apps ==
     # Program("app_nn", [], 2 ** 14, custom_arguments=["-std=c99", "-Wno-unknown-attributes", "-DARM_MATH_CM3", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/DSP/Include", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/Core/Include", "-I/Users/peachg/Projects/CMSIS_5_NN/CMSIS_5/CMSIS/NN/Include"]),
-    Program("app_pid", ["-std=c++11", "-Wall"], 2 ** 8, custom_arguments=[], is_cpp=True),
-    Program("app_tiny_ekf", ["-std=c++11", "-Wall"], 2 ** 14, custom_arguments=[], is_cpp=True),
-    Program("app_tinycrypt", [], 2 ** 15 + 2**14, custom_arguments=[ "-Wall", "-Wpedantic", "-Wno-gnu-zero-variadic-macro-arguments", "-std=c11", "-I/Users/peachg/Projects/silverfish/code_benches/app_tinycrypt/", "-DENABLE_TESTS", "-I."]),
+#    Program("app_pid", ["-std=c++11", "-Wall"], 2 ** 8, custom_arguments=[], is_cpp=True),
+#    Program("app_tiny_ekf", ["-std=c++11", "-Wall"], 2 ** 14, custom_arguments=[], is_cpp=True),
+#    Program("app_tinycrypt", [], 2 ** 15 + 2**14, custom_arguments=[ "-Wall", "-Wpedantic", "-Wno-gnu-zero-variadic-macro-arguments", "-std=c11", "-I/Users/peachg/Projects/silverfish/code_benches/app_tinycrypt/", "-DENABLE_TESTS", "-I."]),
     # Program("app_v9", [], 2 ** 18, custom_arguments=[], do_lto=False),
 
     # == MiBench ==

--- a/tests/code_benches.rs
+++ b/tests/code_benches.rs
@@ -1,0 +1,32 @@
+use std::error;
+use std::process;
+
+#[cfg(debug_assertions)]
+const CLI: &str = "./target/debug/silverfish";
+#[cfg(not(debug_assertions))]
+const CLI: &str = "./target/release/silverfish";
+
+#[test]
+fn cli_help_test() -> Result<(), Box<dyn error::Error>> {
+    // sanity check that code compiles and runs
+    let mut command = process::Command::new(CLI);
+    command.args(&["--help"]);
+    println!("{:?}", command);
+    let status = command.output()?.status;
+    assert!(status.success());
+    Ok(())
+}
+
+#[test]
+fn code_benches_test() -> Result<(), Box<dyn error::Error>> {
+    // run oode_benches
+    let mut command = process::Command::new("code_benches/run.py");
+    if cfg!(not(debug_assertions)) {
+        command.args(&["--release"]);
+    }
+    println!("{:?}", command);
+    let status = command.status()?;
+    assert!(status.success());
+    Ok(())
+}
+

--- a/tests/code_benches.rs
+++ b/tests/code_benches.rs
@@ -21,7 +21,9 @@ fn cli_help_test() -> Result<(), Box<dyn error::Error>> {
 fn code_benches_test() -> Result<(), Box<dyn error::Error>> {
     // run oode_benches
     let mut command = process::Command::new("code_benches/run.py");
-    if cfg!(not(debug_assertions)) {
+    if cfg!(debug_assertions) {
+        command.args(&["--debug"]);
+    } else {
         command.args(&["--release"]);
     }
     println!("{:?}", command);


### PR DESCRIPTION
Here were the changes needed to get the code_benches running on Ubuntu 19.10, Rust 1.45.0, LLVM 9.0.0

Changes:
- Replaced shopt with python's glob.glob.

  Needed as Linux defaults to sh with shell=True. There is an executable argument to allow passing bash, but I'm not sure it's portable to other OSs

- Added -DSQLITE_MUTEX_NOOP and -ldl to get custom_sqlite compiling
- Disabled app_nn for now, depends on arm_math and won't work portably
- Added -I. to tinycrypt since it seems to use `<anglebrackets>` for its includes.

I also added a stub to tests/code_benches.rs (new file) so that `cargo test` runs code_benches/run.py. This is not needed so I can remove if you'd like.

~Also note this is currently built on https://github.com/gwsystems/aWsm/pull/10, since I needed it to get aWsm running. Happy to rebase once https://github.com/gwsystems/aWsm/issues/9 is resolved.~ Rebasing onto current fix, see thread