### PR TITLE
 Added codegen for memory.size and memory.grow instructions 

### DIFF
--- a/runtime/memory/64bit_nix.c
+++ b/runtime/memory/64bit_nix.c
@@ -37,6 +37,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     // Due to how we setup memory for x86, the virtual memory mechanism will catch the error, if bounds < WASM_PAGE_SIZE
     assert(bounds_check < WASM_PAGE_SIZE || (memory_size > bounds_check && offset <= memory_size - bounds_check));

--- a/runtime/memory/cortex_m.c
+++ b/runtime/memory/cortex_m.c
@@ -32,6 +32,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     silverfish_assert(offset <= memory_size - bounds_check);
 

--- a/runtime/memory/cortex_m_no_protection.c
+++ b/runtime/memory/cortex_m_no_protection.c
@@ -33,6 +33,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     char* mem_as_chars = (char *) memory;
     char* address = &mem_as_chars[offset];

--- a/runtime/memory/cortex_m_spt.c
+++ b/runtime/memory/cortex_m_spt.c
@@ -43,6 +43,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     char* mem_as_chars = (char *) memory;
     char* address = &mem_as_chars[offset];

--- a/runtime/memory/cortex_m_wrapping.c
+++ b/runtime/memory/cortex_m_wrapping.c
@@ -27,6 +27,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     silverfish_assert(offset <= memory_size - bounds_check);
 

--- a/runtime/memory/generic.c
+++ b/runtime/memory/generic.c
@@ -22,6 +22,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     silverfish_assert(memory_size > bounds_check && offset <= memory_size - bounds_check);
 

--- a/runtime/memory/mpx.c
+++ b/runtime/memory/mpx.c
@@ -23,6 +23,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     assert(memory_size > bounds_check && offset <= memory_size - bounds_check);
 

--- a/runtime/memory/no_protection.c
+++ b/runtime/memory/no_protection.c
@@ -20,6 +20,19 @@ void expand_memory() {
     memory_size += WASM_PAGE_SIZE;
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     char* mem_as_chars = (char *) memory;
     return &mem_as_chars[offset];

--- a/runtime/memory/segmented.c
+++ b/runtime/memory/segmented.c
@@ -87,6 +87,19 @@ void expand_memory() {
     set_seg_registers();
 }
 
+i32 instruction_memory_size() {
+    return memory_size / WASM_PAGE_SIZE;
+}
+
+i32 instruction_memory_grow(i32 count) {
+    i32 prev_size = instruction_memory_size();
+    for (int i = 0; i < count; i++) {
+        expand_memory();
+    }
+
+    return prev_size;
+}
+
 INLINE char* get_memory_ptr_for_runtime(u32 offset, u32 bounds_check) {
     assert(memory_size > bounds_check && offset <= memory_size - bounds_check);
 

--- a/src/codegen/block.rs
+++ b/src/codegen/block.rs
@@ -1032,6 +1032,17 @@ pub fn compile_block<'a, 'b>(
                 let v = stack.pop().unwrap();
                 store_val::<f64>(m_ctx, b, &mut stack, offset, v);
             }
+
+            Instruction::MemorySize => {
+                let result = b.build_call(get_stub_function(m_ctx, MEMORY_SIZE), &[]);
+                stack.push(result);
+            }
+            Instruction::MemoryGrow => {
+                let v = stack.pop().unwrap();
+                assert_type(m_ctx, v, Type::I32);
+                let result = b.build_call(get_stub_function(m_ctx, MEMORY_GROW), &[v]);
+                stack.push(result);
+            }
         }
     }
 }

--- a/src/codegen/runtime_stubs.rs
+++ b/src/codegen/runtime_stubs.rs
@@ -12,6 +12,9 @@ use crate::codegen::Opt;
 // Backing functions for wasm operations
 pub const INITIALIZE_REGION_STUB: &str = "initialize_region";
 
+pub const MEMORY_SIZE: &str = "instruction_memory_size";
+pub const MEMORY_GROW: &str = "instruction_memory_grow";
+
 pub const GET_F32: &str = "get_f32";
 pub const SET_F32: &str = "set_f32";
 
@@ -108,6 +111,12 @@ pub fn insert_runtime_stubs(opt: &Opt, ctx: &LLVMCtx, m: &LLVMModule) {
         ],
     );
     m.add_function(INITIALIZE_REGION_STUB, initialize_region_type.to_super());
+
+    // Memory region manipulation stubs
+    let memory_size_ty = FunctionType::new(<i32>::get_type(ctx), &[]);
+    m.add_function(MEMORY_SIZE, memory_size_ty.to_super());
+    let memory_grow_ty = FunctionType::new(<i32>::get_type(ctx), &[<i32>::get_type(ctx)]);
+    m.add_function(MEMORY_GROW, memory_grow_ty.to_super());
 
     // Table interaction function stubs
     let table_add_type = FunctionType::new(

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -440,6 +440,9 @@ pub enum Instruction {
 
     F64Load { flags: u32, offset: u32 },
     F64Store { flags: u32, offset: u32 },
+
+    MemorySize,
+    MemoryGrow,
 }
 
 impl<'a> From<&'a Operator<'a>> for Instruction {
@@ -752,6 +755,9 @@ impl<'a> From<&'a Operator<'a>> for Instruction {
                 flags: memarg.flags,
                 offset: memarg.offset,
             },
+
+            Operator::MemorySize { .. } => Instruction::MemorySize,
+            Operator::MemoryGrow { .. } => Instruction::MemoryGrow,
 
             ref e => unimplemented!("{:?}", e),
         }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -977,7 +977,12 @@ impl WasmModule {
                             mutable: global_ty.mutable,
                         });
                     }
-                    e => panic!("Have not implemented import section entry type {:?}", e),
+                    ImportSectionEntryType::Memory(memory_ty) => {
+                        self.memories.push(*memory_ty);
+                    }
+                    ImportSectionEntryType::Table(table_ty) => {
+                        self.tables.push(*table_ty);
+                    }
                 }
                 ProcessState::ImportSection
             }


### PR DESCRIPTION
Creating PR for review, currently building off of https://github.com/gwsystems/aWsm/pull/12, happy to rebase on what changes goes in. Only the last commit should be relevant: https://github.com/gwsystems/aWsm/commit/fc2bbe57ffc9304b28dab29b3b3dcd3dc5e25be0

I tried to follow the implementation of instruction->runtime function instructions, so hopefully this is better than my previous attempt (https://github.com/gwsystems/aWsm/pull/2).

Currently linking to `memory_grow` and `memory_size_`. Need to fix the name conflict with the `memory_size` variable, though happy to take alternative names.

Have we considered prefixing all of the runtime functions with something like `awsmr_memory_grow`?

