### PR TITLE
Remove direct llvm-sys dependency, cleanup imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,12 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,9 +139,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7d4bd64732af4bf3a67f367c27df8520ad7e230c5817b8ff485864d80242b9"
+checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
 name = "llvm-alt"
@@ -156,7 +150,7 @@ source = "git+https://github.com/Others/llvm-rs.git#4f825ff10f7bdc20a3beb2bca648
 dependencies = [
  "cbox",
  "libc",
- "llvm-sys 0.3.0",
+ "llvm-sys",
 ]
 
 [[package]]
@@ -167,20 +161,7 @@ dependencies = [
  "bitflags 0.5.0",
  "gcc",
  "libc",
- "semver 0.1.20",
-]
-
-[[package]]
-name = "llvm-sys"
-version = "90.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a37c65d26686a37e9a32ef9a41a74333e6dee8b780cc9d29eb33cacdbb12f5"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "regex",
- "semver 0.9.0",
+ "semver",
 ]
 
 [[package]]
@@ -286,27 +267,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "silverfish"
 version = "0.1.0"
 dependencies = [
  "flexi_logger",
  "llvm-alt",
- "llvm-sys 90.1.0",
  "log",
  "structopt",
  "wasmparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 flexi_logger = "0.14.4"
-llvm-sys = "90.0.0"
 llvm-alt = { git = "https://github.com/Others/llvm-rs.git"}
 log = "0.4.8"
 structopt = "0.3.2"

--- a/code_benches/run.py
+++ b/code_benches/run.py
@@ -4,7 +4,7 @@ import subprocess as sp
 import sys
 import timeit
 
-# Note: This is a major configuration option, you probably want to set this if you're doing anything advanced
+# Note: This is a major configuration option, you probably want to set this if you're doing anything non-trivial
 SILVERFISH_TARGET = None
 # SILVERFISH_TARGET = "thumbv7em-none-unknown-eabi"
 # SILVERFISH_TARGET = "x86_64-apple-macosx10.15.0"

--- a/src/codegen/block.rs
+++ b/src/codegen/block.rs
@@ -7,19 +7,19 @@ use llvm::Value;
 
 use wasmparser::Type;
 
-use super::super::wasm::Instruction;
+use crate::codegen::ModuleCtx;
 
-use super::ModuleCtx;
+use crate::codegen::breakout::BreakoutTarget;
+use crate::codegen::breakout::WBreakoutTarget;
 
-use super::breakout::BreakoutTarget;
-use super::breakout::WBreakoutTarget;
+use crate::codegen::function::FunctionCtx;
 
-use super::function::FunctionCtx;
+use crate::codegen::runtime_stubs::*;
 
-use super::runtime_stubs::*;
+use crate::codegen::type_conversions::llvm_type_to_wasm_type;
+use crate::codegen::type_conversions::wasm_func_type_to_llvm_type;
 
-use super::type_conversions::llvm_type_to_wasm_type;
-use super::type_conversions::wasm_func_type_to_llvm_type;
+use crate::wasm::Instruction;
 
 // TODO: Double check each instruction to make sure it does the right thing in both the safe and unsafe case
 

--- a/src/codegen/breakout.rs
+++ b/src/codegen/breakout.rs
@@ -8,8 +8,8 @@ use llvm::Value;
 
 use wasmparser::TypeOrFuncType;
 
-use super::type_conversions::llvm_type_to_zeroed_value;
-use super::type_conversions::wasm_type_to_zeroed_value;
+use crate::codegen::type_conversions::llvm_type_to_zeroed_value;
+use crate::codegen::type_conversions::wasm_type_to_zeroed_value;
 
 pub struct BreakoutTarget<'a> {
     pub bb: &'a BasicBlock,

--- a/src/codegen/globals.rs
+++ b/src/codegen/globals.rs
@@ -8,14 +8,14 @@ use llvm::Value;
 
 use wasmparser::Type;
 
-use super::super::wasm::Global;
-use super::super::wasm::Instruction;
-use super::super::Opt;
+use crate::wasm::Global;
+use crate::wasm::Instruction;
+use crate::Opt;
 
-use super::runtime_stubs::*;
-use super::type_conversions::llvm_type_to_wasm_type;
-use super::type_conversions::wasm_type_to_llvm_type;
-use super::ModuleCtx;
+use crate::codegen::ModuleCtx;
+use crate::codegen::runtime_stubs::*;
+use crate::codegen::type_conversions::llvm_type_to_wasm_type;
+use crate::codegen::type_conversions::wasm_type_to_llvm_type;
 
 pub enum GlobalValue<'a> {
     InlinedConstant(&'a Value),

--- a/src/codegen/memory.rs
+++ b/src/codegen/memory.rs
@@ -1,4 +1,3 @@
-use llvm;
 use llvm::Builder;
 use llvm::Compile;
 use llvm::FunctionType;
@@ -6,16 +5,15 @@ use llvm::PointerType;
 use llvm::Sub;
 use llvm::Value;
 
-use wasmparser;
 use wasmparser::ResizableLimits;
 
-use super::super::wasm::DataInitializer;
-use super::super::wasm::ImplementedFunction;
-use super::super::wasm::Instruction;
+use crate::wasm::DataInitializer;
+use crate::wasm::ImplementedFunction;
+use crate::wasm::Instruction;
 
-use super::function::compile_function;
-use super::type_conversions::wasm_func_type_to_llvm_type;
-use super::ModuleCtx;
+use crate::codegen::ModuleCtx;
+use crate::codegen::function::compile_function;
+use crate::codegen::type_conversions::wasm_func_type_to_llvm_type;
 
 // We add in globals to tell the runtime how much memory to allocate and startup
 // (And what the max amount of allocated memory should be)

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -6,11 +6,11 @@ use llvm::Module as LLVMModule;
 
 use wasmparser::FuncType;
 
+use crate::Opt;
+
 use crate::wasm::Export;
 use crate::wasm::Function;
 use crate::wasm::WasmModule;
-
-use super::Opt;
 
 mod block;
 

--- a/src/codegen/runtime_stubs.rs
+++ b/src/codegen/runtime_stubs.rs
@@ -6,8 +6,8 @@ use llvm::Module as LLVMModule;
 use llvm::PointerType;
 use llvm::Sub;
 
-use super::ModuleCtx;
-use super::Opt;
+use crate::codegen::ModuleCtx;
+use crate::codegen::Opt;
 
 // Backing functions for wasm operations
 pub const INITIALIZE_REGION_STUB: &str = "initialize_region";

--- a/src/codegen/table.rs
+++ b/src/codegen/table.rs
@@ -1,17 +1,15 @@
-use llvm;
 use llvm::Builder;
 use llvm::Compile;
 use llvm::FunctionType;
 use llvm::PointerType;
 use llvm::Sub;
 
-use super::super::wasm::TableInitializer;
+use crate::wasm::TableInitializer;
 
-use super::ModuleCtx;
+use crate::codegen::ModuleCtx;
+use crate::codegen::memory::generate_offset_function;
 
-use super::memory::generate_offset_function;
-
-use super::runtime_stubs::*;
+use crate::codegen::runtime_stubs::*;
 
 pub fn generate_table_initialization_stub(m_ctx: &ModuleCtx, initializers: Vec<TableInitializer>) {
     let mut initialization_data: Vec<(&llvm::Function, Vec<u32>)> = Vec::new();

--- a/src/codegen/type_conversions.rs
+++ b/src/codegen/type_conversions.rs
@@ -1,12 +1,9 @@
 use std::ptr;
 
-use llvm;
 use llvm::ffi::prelude::LLVMTypeRef;
 use llvm::Compile;
 use llvm::Context;
 use llvm::Sub;
-
-use wasmparser;
 
 pub fn llvm_type_to_wasm_type(ctx: &Context, ty: &llvm::Type) -> wasmparser::Type {
     let ty_ref: LLVMTypeRef = ty.into();

--- a/src/llvm_externs.rs
+++ b/src/llvm_externs.rs
@@ -1,0 +1,38 @@
+#![allow(non_upper_case_globals)]
+
+use std::os::raw::c_char;
+use std::os::raw::c_uint;
+
+use llvm::ffi::LLVMAttribute;
+use llvm::ffi::LLVMContext;
+use llvm::ffi::LLVMValue;
+
+// WARNING: This is a bit of hack, and we can hopefully replace llvm_alt with `inkwell` at some point
+// We already link LLVM thru llvm_alt, but it fails to pick up a few functions we need
+
+pub const LLVMAttributeFunctionIndex: c_uint = !0;
+
+pub type LLVMAttributeRef = *mut LLVMAttribute;
+
+extern "C" {
+    pub fn LLVMAddAttributeAtIndex(F: *mut LLVMValue, Idx: u32, A: LLVMAttributeRef);
+
+    pub fn LLVMCreateEnumAttribute(
+        C: *mut LLVMContext,
+        KindID: c_uint,
+        Val: u64,
+    ) -> LLVMAttributeRef;
+
+    pub fn LLVMCreateStringAttribute(
+        C: *mut LLVMContext,
+        K: *const c_char,
+        KLength: c_uint,
+        V: *const c_char,
+        VLength: c_uint,
+    ) -> LLVMAttributeRef;
+
+    pub fn LLVMGetEnumAttributeKindForName(
+        Name: *const c_char,
+        SLen: usize,
+    ) -> c_uint;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@ use crate::codegen::process_to_llvm;
 mod wasm;
 use crate::wasm::WasmModule;
 
+pub mod llvm_externs;
+
 #[derive(StructOpt, Debug)]
 #[structopt(name = "silverfish")]
 pub struct Opt {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -963,7 +963,7 @@ impl WasmModule {
                     ImportSectionEntryType::Global(global_ty) => {
                         let source = module.to_string();
                         let name = field.to_string();
-                        let appended = source.clone() + "_" + &name;
+                        let appended = source + "_" + &name;
 
                         self.globals.push(Global::Imported {
                             name: appended,
@@ -1058,7 +1058,7 @@ impl WasmModule {
             &ParserState::FunctionBodyLocals { ref locals } => {
                 for (i, ty) in locals.iter() {
                     for _ in 0..*i {
-                        f.locals.push(ty.clone());
+                        f.locals.push(*ty);
                     }
                 }
                 ProcessState::FunctionCode(f)


### PR DESCRIPTION
Should fix any double-linking problems at the cost of a bit of tech debt. Alternative to #10.

I think this probably is better than hiding features behind a feature flag. @geky can you test whether this fixes your linking problems, the way #10 did?