### PR TITLE
Resolve Mac Build Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ silverfish.iml
 .vagrant
 Vagrantfile
 *-cloudimg-console.log
+
+wasi-sdk
+.vscode

--- a/code_benches/run.py
+++ b/code_benches/run.py
@@ -91,9 +91,16 @@ WASI_SDK_CLANG = WASI_SDK_PATH + "/bin/clang"
 WASI_SDK_SYSROOT = WASI_SDK_PATH + "/share/wasi-sysroot"
 WASI_SDK_FLAGS = "--target=wasm32-wasi -mcpu=mvp -nostartfiles -O3 -flto"
 WASI_SDK_BACKING = "wasi_sdk_backing.c"
-WASI_SDK_URL = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-linux.tar.gz"
 
 # download WASI-SDK if it is not in the expected path
+if sys.platform == "linux" or sys.platform == "linux2":
+    WASI_SDK_URL = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-linux.tar.gz"
+elif sys.platform == "darwin":
+    WASI_SDK_URL = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-macos.tar.gz"
+else:
+    print("awsm supports Linux and Mac OS, saw {}".format(sys.platform))
+    exit(1)
+
 if args.wasi_sdk:
     if not os.path.exists(WASI_SDK_PATH):
         cwd = os.path.dirname(WASI_SDK_PATH)

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -11,6 +11,7 @@ fi
 # Install required tools
 brew install svn
 brew install wget
+brew install cmake
 
 # Install LLVM and clang stuff
 xcode-select install

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -2,11 +2,10 @@
 git submodule update --init --recursive
 
 # Install brew
-if ! command -v brew &> /dev/null
-then 
-  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash -s -- -y
-else
+if [[ -x "$(command -v brew)" ]]; then
   echo "Brew install detected"
+else
+  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash -s -- -y
 fi
 
 # Install required tools
@@ -15,12 +14,11 @@ brew install wget
 
 # Install LLVM and clang stuff
 xcode-select install
-if ! command -v llvm-config &> /dev/null
-then 
-    brew install llvm
-    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.zshrc
+if [[ -x "$(command -v rustup)" ]]; then
+  echo "LLVM detected"
 else
-    echo "LLVM detected"
+  brew install llvm
+  echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >>~/.zshrc
 fi
 
 # Install Rust

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 git submodule update --init --recursive
 
-# Uncomment to install brew
+# Install brew
 if ! command -v brew &> /dev/null
 then 
   curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash -s -- -y

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+git submodule update --init --recursive
+
+# Uncomment to install brew
+if ! command -v brew &> /dev/null
+then 
+  curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash -s -- -y
+else
+  echo "Brew install detected"
+fi
+
+# Install required tools
+brew install svn
+brew install wget
+
+# Install LLVM and clang stuff
+xcode-select install
+if ! command -v llvm-config &> /dev/null
+then 
+    brew install llvm
+    echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.zshrc
+else
+    echo "LLVM detected"
+fi
+
+# Install Rust
+if [[ -x "$(command -v rustup)" ]]; then
+  rustup update
+else
+  curl https://sh.rustup.rs -sSf | bash -s -- -y
+fi
+source "$HOME/.cargo/env"
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Build project
+cargo build --release

--- a/runtime/libc/env.c
+++ b/runtime/libc/env.c
@@ -145,15 +145,3 @@ env_getcycles(void)
 
     #endif
 }
-
-// Floating point routines
-// TODO: Do a fair comparison between musl and wasm-musl
-INLINE double
-env_sin(double d) {
-    return sin(d);
-}
-
-INLINE double
-env_cos(double d) {
-    return cos(d);
-}

--- a/runtime/libc/wasi_sdk_backing.c
+++ b/runtime/libc/wasi_sdk_backing.c
@@ -387,7 +387,7 @@ i32 wasi_unstable_fd_fdstat_set_flags(i32 fd, u32 fdflags) {
         ((flags & WASI_FDFLAG_APPEND  ) ? O_APPEND   : 0) |
         ((flags & WASI_FDFLAG_DSYNC   ) ? O_DSYNC    : 0) |
         ((flags & WASI_FDFLAG_NONBLOCK) ? O_NONBLOCK : 0) |
-        ((flags & WASI_FDFLAG_RSYNC   ) ? O_RSYNC : 0) |
+        ((flags & WASI_FDFLAG_RSYNC   ) ? O_RSYNC    : 0) |
         ((flags & WASI_FDFLAG_SYNC    ) ? O_SYNC     : 0));
     int err = fcntl(fd, F_SETFL, fdflags);
     if (err < 0) {

--- a/runtime/libc/wasi_sdk_backing.c
+++ b/runtime/libc/wasi_sdk_backing.c
@@ -22,8 +22,8 @@
 #define O_RSYNC O_SYNC
 #endif
 
-/* POSIX Systems with fdatasync available define _POSIX_SYNCHRONIZED_IO in unistd.h */
-#ifndef _POSIX_SYNCHRONIZED_IO 
+#ifdef __APPLE__
+#undef fdatasync
 #define fdatasync fsync
 #endif
 

--- a/runtime/libc/wasmception_backing.c
+++ b/runtime/libc/wasmception_backing.c
@@ -627,3 +627,15 @@ void env___unmapself(u32 base, u32 size) {
     // Just do some no op
 }
 
+// Floating point routines
+// TODO: Do a fair comparison between musl and wasm-musl
+INLINE double
+env_sin(double d) {
+    return sin(d);
+}
+
+INLINE double
+env_cos(double d) {
+    return cos(d);
+}
+

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -207,27 +207,7 @@ INLINE double f64_copysign(double a, double b) {
     return copysign(a, b);
 }
 
-// Memory related instructions
-/* instruction_memory_size and instruction_memory_grow are identical in this 
- * translation unit and all of the runtime/memory translation units. This is
- * causing linking errors because multiple translation units are trying to
- * define the same global symbol. I've set these functions to static for a
- * temporary fix pending a discussion of possible refactors. */
-static i32 instruction_memory_size() {
-    return memory_size / WASM_PAGE_SIZE;
-}
-
-static i32 instruction_memory_grow(i32 count) {
-    i32 prev_size = instruction_memory_size();
-    for (int i = 0; i < count; i++) {
-        expand_memory();
-    }
-
-    return prev_size;
-}
-
-
-// We want to have some allocation logic
+// We want to have some allocation logic here, so we can use it to implement libc
 WEAK u32 wasmg___heap_base = 0;
 u32 runtime_heap_base;
 

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -208,11 +208,16 @@ INLINE double f64_copysign(double a, double b) {
 }
 
 // Memory related instructions
-i32 instruction_memory_size() {
+/* instruction_memory_size and instruction_memory_grow are identical in this 
+ * translation unit and all of the runtime/memory translation units. This is
+ * causing linking errors because multiple translation units are trying to
+ * define the same global symbol. I've set these functions to static for a
+ * temporary fix pending a discussion of possible refactors. */
+static i32 instruction_memory_size() {
     return memory_size / WASM_PAGE_SIZE;
 }
 
-i32 instruction_memory_grow(i32 count) {
+static i32 instruction_memory_grow(i32 count) {
     i32 prev_size = instruction_memory_size();
     for (int i = 0; i < count; i++) {
         expand_memory();

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -113,6 +113,9 @@ INLINE double get_f64(u32 offset);
 INLINE void set_f32(u32 offset, float);
 INLINE void set_f64(u32 offset, double);
 
+i32 instruction_memory_size();
+i32 instruction_memory_grow();
+
 static inline void* get_memory_ptr_void(u32 offset, u32 bounds_check) {
     return (void*) get_memory_ptr_for_runtime(offset, bounds_check);
 }


### PR DESCRIPTION
A handful of fixes and QOL improvements for Mac. I made a first pass as an install script based on what I had to manually install to get things working.

I think the main thing worth discussing is the linking errors I hit (likely currently broken at head of master). I'm unclear why I didn't hit this when running the branch, but I suspect that perhaps some build asset was cached and I wasn't clear how to do the equivalent of a `make clean`. In any case, there are two functions that seem to be duplicated across a number of files. My preference would be to DRY that up in a follow-up issue, but we should make sure I understand all the different permutations of how things get compiled. It seemed like each compiled aWsm module links in both `runtime.c` and one of the memory translation units. 