### PR TITLE
feat: Implement random_get syscall

### DIFF
--- a/runtime/libc/wasi_sdk_backing.c
+++ b/runtime/libc/wasi_sdk_backing.c
@@ -1104,7 +1104,16 @@ wasi_errno_t wasi_snapshot_preview1_random_get(
     wasi_size_t buf_baseretptr,
     wasi_size_t buf_len
 ) {
-    wasi_unsupported_syscall(__func__);
+    srandom(time(NULL));
+    wasi_size_t buf_cursor = 0; 
+    for (; (buf_len - buf_cursor) >= 4; buf_cursor += 4) {
+        set_i64(buf_baseretptr + buf_cursor, random());
+    }
+    for (; buf_cursor < buf_len; buf_cursor += 1){
+        set_i8(buf_baseretptr  + buf_cursor, random() % UINT8_MAX);
+    }
+
+    return WASI_ESUCCESS;
 }
 
 /**

--- a/tests/wat/.gitignore
+++ b/tests/wat/.gitignore
@@ -1,5 +1,4 @@
 *.bc
-if_vm
 *.wasm
 *.ll
-args_vm
+*_vm

--- a/tests/wat/Makefile
+++ b/tests/wat/Makefile
@@ -20,7 +20,7 @@ WASM_BACKING:=${WASI_SDK_BACKING}
 # Excludes stack-size, as this may vary between apps
 WASM_LINKER_FLAGS:=-Wl,--allow-undefined,--no-threads,--stack-first,--no-entry,--export-all,--export=main,--export=dummy
 
-clean: if_clean args_clean
+clean: if_clean args_clean random_clean
 
 # Should work for Linux. Alternate installation options at https://wasmtime.dev/
 .PHONY: install_wasmtime
@@ -76,3 +76,28 @@ args_vm: args.bc
 .PHONY: args_clean
 args_clean:
 	@rm -f args.wasm args.bc args_vm
+
+random.wasm: random.wat
+	@wat2wasm random.wat -o random.wasm
+
+.PHONY: random_wasmtime
+random_wasmtime: random.wasm
+	@wasmtime random.wasm arg1 arg2 arg3
+
+random.bc: random.wasm
+	@RUST_BACKTRACE=1 ${AWSM_CC} ./random.wasm -o ./random.bc
+
+random_vm: random.bc
+	@${CC} -lm ${OPTFLAGS} \
+	./random.bc \
+	${RUNTIME_PATH}/runtime.c \
+	${RUNTIME_PATH}/libc/${WASM_BACKING} \
+	${RUNTIME_PATH}/libc/env.c \
+	${RUNTIME_PATH}/memory/64bit_nix.c \
+	-o ./random_vm
+
+.PHONY: random_clean
+random_clean:
+	@rm -f random.wasm random.bc random_vm
+
+

--- a/tests/wat/random.wat
+++ b/tests/wat/random.wat
@@ -1,0 +1,49 @@
+(module
+    (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+    (import "wasi_snapshot_preview1" "random_get" (func $random_get (param i32 i32) (result i32)))
+    (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+    
+    (memory 1)
+    (export "memory" (memory 0))
+
+    (table $tbl 0 anyfunc)
+
+    ;; We also need to manually stub out this function
+    (func (export "__wasm_call_ctors"))
+
+    (func $panic
+        (i32.store (i32.const 0) (i32.const 8))  ;; iov.iov_base 
+        (i32.store (i32.const 4) (i32.const 6))  ;; iov.iov_len 
+        (call $fd_write
+            (i32.const 1) ;; file_descriptor - 1 for stdout
+            (i32.const 0) ;; *iovs - The pointer to the iov array, which is stored at memory location 0
+            (i32.const 1) ;; iovs_len - We're printing 1 string stored in an iov - so one.
+            (i32.const 20) ;; nwritten - A place in memory to store the number of bytes written
+        )
+        drop ;; Discard the number of bytes written from the top of the stack
+        (call $proc_exit (i32.const 1))
+    )
+    ;; Returns the number of passed tests
+    (func $_start (export "_start")
+        (call $random_get (i32.const 0) (i32.const 5))
+        drop
+
+        (i32.store (i32.const 8) (i32.const 0))  ;; iov.iov_base 
+        (i32.store (i32.const 12) (i32.const 5))  ;; iov.iov_len 
+
+        (call $fd_write
+            (i32.const 1) ;; file_descriptor - 1 for stdout
+            (i32.const 8) ;; *iovs - The pointer to the iov array, which is stored at memory location 0
+            (i32.const 1) ;; iovs_len - We're printing 1 string stored in an iov - so one.
+            (i32.const 20) ;; nwritten - A place in memory to store the number of bytes written
+        )
+        drop
+
+        (call $proc_exit (i32.const 0))
+    )
+
+    ;; awsm uses main as the entrypoint, not the normal WASI _start
+    (func (export "main")
+        (call $_start)
+    )
+)


### PR DESCRIPTION
- Implements the `random_get` syscall
- There isn't a clear libc mapping to this, so wrote a WAT test program that calls the syscall direct and prints the random values to STDOUT