### PR TITLE
fix: hack WASI status code width to match wasm32 ABI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = wasmception
 	url = https://github.com/gwsystems/wasmception.git
 	branch = sfbase
+[submodule "example_code/sod_samples/sod"]
+	path = example_code/sod_samples/sod
+	url = git@github.com:gwsystems/sod.git
+	branch = sledge

--- a/example_code/sod_samples/.gitignore
+++ b/example_code/sod_samples/.gitignore
@@ -1,0 +1,4 @@
+resize.bc
+resize.jpg
+resize.wasm
+resize_vm

--- a/example_code/sod_samples/Makefile
+++ b/example_code/sod_samples/Makefile
@@ -1,23 +1,19 @@
 CC=clang
-OPTFLAGS=-O0 -g
+OPTFLAGS=-O3 -flto
 
 ROOT_PATH:=../..
 
 WASM_CC:=${ROOT_PATH}/wasi-sdk/bin/clang
 WASI_SDK_SYSROOT:=${ROOT_PATH}/wasi-sdk/share/wasi-sysroot
 WASM_FLAGS:=--target=wasm32-wasi -mcpu=mvp ${OPTFLAGS} --sysroot=${WASI_SDK_SYSROOT}
-WASM_LINKER_FLAGS:=-Wl,--allow-undefined,--threads=1
-
-lpd.wasm: ./sod/sod.c ./sod/samples/license_plate_detection.c
-	@mkdir -p ./app_pid/bin
-	${WASM_CC} ${WASM_FLAGS} ${WASM_LINKER_FLAGS} -D_WASI_EMULATED_MMAN -Wl,-z,stack-size=256,-lwasi-emulated-mman  -I./sod -Wall ./sod/sod.c ./sod/samples/license_plate_detection.c -o lpd.wasm
+WASM_LINKER_FLAGS:=-Wl,--allow-undefined,--threads=1,--export-all,--no-gc-sections
 
 clean:
 	rm -rf resize resize.wasm resize.bc resize_vm
 
 resize.wasm: ./sod/sod.c ./sod/samples/resize_image.c
 	@mkdir -p ./app_pid/bin
-	${WASM_CC} ${WASM_FLAGS} ${WASM_LINKER_FLAGS} -D_WASI_EMULATED_MMAN -Wl,-z -lwasi-emulated-mman -lm -I./sod -Wall ./sod/sod.c ./sod/samples/resize_image.c -o resize.wasm
+	${WASM_CC} ${WASM_FLAGS} ${WASM_LINKER_FLAGS} -lwasi-emulated-mman -lm -D_WASI_EMULATED_MMAN -I./sod -Wall ./sod/sod.c ./sod/samples/resize_image.c -o resize.wasm
 
 resize: ./sod/sod.c ./sod/samples/resize_image.c 
 	@mkdir -p ./app_pid/bin
@@ -28,7 +24,7 @@ resize.bc: resize.wasm
 
 # Change the optimization level from -O0 to -O1 to trigger the bug
 resize_vm: resize.bc ${ROOT_PATH}/runtime/runtime.c ${ROOT_PATH}/runtime/libc/wasi_sdk_backing.c ${ROOT_PATH}/runtime/libc/env.c ${ROOT_PATH}/runtime/memory/64bit_nix.c
-	clang -lm -O1 -flto -g resize.bc ${ROOT_PATH}/runtime/runtime.c ${ROOT_PATH}/runtime/libc/wasi_sdk_backing.c ${ROOT_PATH}/runtime/libc/env.c ${ROOT_PATH}/runtime/memory/64bit_nix.c -o resize_vm
+	clang -O3 -flto -lm resize.bc ${ROOT_PATH}/runtime/runtime.c ${ROOT_PATH}/runtime/libc/wasi_sdk_backing.c ${ROOT_PATH}/runtime/libc/env.c ${ROOT_PATH}/runtime/memory/64bit_nix.c -o resize_vm
 
 .PHONY: resize_wasmtime
 resize_wasmtime: resize.wasm

--- a/example_code/sod_samples/Makefile
+++ b/example_code/sod_samples/Makefile
@@ -1,0 +1,39 @@
+CC=clang
+OPTFLAGS=-O0 -g
+
+ROOT_PATH:=../..
+
+WASM_CC:=${ROOT_PATH}/wasi-sdk/bin/clang
+WASI_SDK_SYSROOT:=${ROOT_PATH}/wasi-sdk/share/wasi-sysroot
+WASM_FLAGS:=--target=wasm32-wasi -mcpu=mvp ${OPTFLAGS} --sysroot=${WASI_SDK_SYSROOT}
+WASM_LINKER_FLAGS:=-Wl,--allow-undefined,--threads=1
+
+lpd.wasm: ./sod/sod.c ./sod/samples/license_plate_detection.c
+	@mkdir -p ./app_pid/bin
+	${WASM_CC} ${WASM_FLAGS} ${WASM_LINKER_FLAGS} -D_WASI_EMULATED_MMAN -Wl,-z,stack-size=256,-lwasi-emulated-mman  -I./sod -Wall ./sod/sod.c ./sod/samples/license_plate_detection.c -o lpd.wasm
+
+clean:
+	rm -rf resize resize.wasm resize.bc resize_vm
+
+resize.wasm: ./sod/sod.c ./sod/samples/resize_image.c
+	@mkdir -p ./app_pid/bin
+	${WASM_CC} ${WASM_FLAGS} ${WASM_LINKER_FLAGS} -D_WASI_EMULATED_MMAN -Wl,-z -lwasi-emulated-mman -lm -I./sod -Wall ./sod/sod.c ./sod/samples/resize_image.c -o resize.wasm
+
+resize: ./sod/sod.c ./sod/samples/resize_image.c 
+	@mkdir -p ./app_pid/bin
+	${CC} -I./sod -lm -Wall ./sod/sod.c ./sod/samples/resize_image.c -o resize
+
+resize.bc: resize.wasm
+	${ROOT_PATH}/target/release/awsm  resize.wasm -o resize.bc
+
+# Change the optimization level from -O0 to -O1 to trigger the bug
+resize_vm: resize.bc ${ROOT_PATH}/runtime/runtime.c ${ROOT_PATH}/runtime/libc/wasi_sdk_backing.c ${ROOT_PATH}/runtime/libc/env.c ${ROOT_PATH}/runtime/memory/64bit_nix.c
+	clang -lm -O1 -flto -g resize.bc ${ROOT_PATH}/runtime/runtime.c ${ROOT_PATH}/runtime/libc/wasi_sdk_backing.c ${ROOT_PATH}/runtime/libc/env.c ${ROOT_PATH}/runtime/memory/64bit_nix.c -o resize_vm
+
+.PHONY: resize_wasmtime
+resize_wasmtime: resize.wasm
+	wasmtime resize.wasm <./sod/samples/flower.jpg >resize.jpg
+
+.PHONY: resize_awsm
+resize_awsm: resize_vm
+	./resize_vm <./sod/samples/flower.jpg >resize.jpg

--- a/runtime/libc/wasi_sdk_backing.c
+++ b/runtime/libc/wasi_sdk_backing.c
@@ -101,7 +101,6 @@ int main(int argc, char* argv[]) {
 
     atexit(runtime_on_module_exit);
 
-    fprintf(stderr, "Starting Module\n");
     switch_out_of_runtime();
     wasmf__start();
     /* WASI wrappes non zero status codes in exits, but silently returns on status code 0 */
@@ -1072,7 +1071,6 @@ wasi_errno_t wasi_snapshot_preview1_poll_oneoff(
  */
 __attribute__((noreturn))
 void wasi_snapshot_preview1_proc_exit(wasi_exitcode_t exitcode) {
-    fprintf(stderr, "Module exited with WASI exit code %d\n", exitcode);
     switch_into_runtime();
     exit(exitcode);
 }

--- a/runtime/libc/wasi_sdk_backing.c
+++ b/runtime/libc/wasi_sdk_backing.c
@@ -101,6 +101,7 @@ int main(int argc, char* argv[]) {
 
     atexit(runtime_on_module_exit);
 
+    fprintf(stderr, "Starting Module\n");
     switch_out_of_runtime();
     wasmf__start();
     /* WASI wrappes non zero status codes in exits, but silently returns on status code 0 */
@@ -551,7 +552,7 @@ wasi_errno_t wasi_snapshot_preview1_fd_prestat_get(
     wasi_fd_t fd,
     wasi_size_t prestat_retptr 
 ) {
-    wasi_unsupported_syscall(__func__);
+    return WASI_EBADF;
 }
 
 /**
@@ -1071,6 +1072,7 @@ wasi_errno_t wasi_snapshot_preview1_poll_oneoff(
  */
 __attribute__((noreturn))
 void wasi_snapshot_preview1_proc_exit(wasi_exitcode_t exitcode) {
+    fprintf(stderr, "Module exited with WASI exit code %d\n", exitcode);
     switch_into_runtime();
     exit(exitcode);
 }

--- a/runtime/libc/wasi_sdk_backing.h
+++ b/runtime/libc/wasi_sdk_backing.h
@@ -22,7 +22,17 @@ typedef uint64_t wasi_device_t;
  */
 typedef uint64_t wasi_dircookie_t;
 
-typedef uint16_t wasi_errno_t;
+/* 
+ * Technically, this is specified as a uint16_t in WASI. However, there is no 
+ * native i16 type in WebAssembly, so this is zero extended to an uint32_t to 
+ * avoid width issues linking AOT compiled WebAssembly code with the native
+ * library. This could be enhanced to abstract all mediation between the WASI
+ * spec and the WASI libc ABI in a wrapper layer. This would be like wasi-libc,
+ * but in reverse.
+ * 
+ * https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/sources/__wasilibc_real.c
+ */
+typedef uint32_t wasi_errno_t;
 
 /* The state of the file descriptor subscribed to with fd_read or fd_write */
 typedef uint16_t wasi_eventrwflags_t;


### PR DESCRIPTION
This branch is just provided to help others reproduce the SOD application error.