### PR TITLE
test: port f32.min tests

### DIFF
--- a/tests/wat/README.md
+++ b/tests/wat/README.md
@@ -75,6 +75,7 @@ All files need to be added to the Makefile and ./run.sh driver script following 
 | f32                   | N             | N              | N           |
 | f32_bitwise           | N             | N              | N           |
 | f32_cmp               | N             | N              | N           |
+| f32_min               | Y             | N              | N           |
 | f64                   | N             | N              | N           |
 | f64_bitwise           | N             | N              | N           |
 | f64_cmp               | N             | N              | N           |

--- a/tests/wat/f32__min.wat
+++ b/tests/wat/f32__min.wat
@@ -1,0 +1,1611 @@
+(module
+	(import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+	(memory 1)
+
+	(func $min (export "min") (param $x f32) (param $y f32) (result f32) (f32.min (local.get $x) (local.get $y)))
+	
+	(func $_start (export "_start")
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x1p-149)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x1p-149)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x1p-126)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x1p-126)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x1p-1)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x1p-1)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x1p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x1p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x1.921fb6p+2)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x1.921fb6p+2)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const 0x1.fffffep+127)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const 0x1.fffffep+127)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x0p+0) (f32.const inf)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x0p+0) (f32.const inf)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x0p+0) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x0p+0) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x0p+0) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x0p+0) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x0p+0) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x0p+0) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x0p+0)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x0p+0)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x1p-126)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x1p-126)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x1p-1)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x1p-1)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x1p+0)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x1p+0)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x1.921fb6p+2)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x1.921fb6p+2)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const 0x1.fffffep+127)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const 0x1.fffffep+127)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-149) (f32.const inf)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-149) (f32.const inf)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-149) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-149) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-149) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-149) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-149) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-149) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x0p+0)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x0p+0)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x1p-149)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x1p-149)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x1p-126)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x1p-1)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x1p-1)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x1p+0)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x1p+0)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x1.921fb6p+2)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x1.921fb6p+2)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const 0x1.fffffep+127)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const 0x1.fffffep+127)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-126) (f32.const inf)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-126) (f32.const inf)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-126) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-126) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-126) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-126) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-126) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-126) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x0p+0)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x0p+0)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x1p-149)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x1p-149)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x1p-126)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x1p-126)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x1p-126)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x1p-1)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x1p+0)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x1p+0)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x1.921fb6p+2)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x1.921fb6p+2)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const 0x1.fffffep+127)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const 0x1.fffffep+127)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p-1) (f32.const inf)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p-1) (f32.const inf)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-1) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-1) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p-1) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-1) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-1) (f32.const nan)) (f32.const nan:canonical))(then     
+			;; (call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p-1) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+			;; (call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x0p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x0p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x1p-149)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x1p-149)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x1p-126)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x1p-126)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x1p-126)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x1p-1)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x1p-1)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x1p-1)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x1p+0)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x1.921fb6p+2)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x1.921fb6p+2)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const 0x1.fffffep+127)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const 0x1.fffffep+127)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1p+0) (f32.const inf)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1p+0) (f32.const inf)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p+0) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p+0) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1p+0) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p+0) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p+0) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1p+0) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x0p+0)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x0p+0)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x1p-149)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x1p-149)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x1p-126)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x1p-126)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x1p-126)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x1p-1)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x1p-1)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x1p-1)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x1p+0)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x1p+0)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x1p+0)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x1.921fb6p+2)) (f32.const 0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const 0x1.fffffep+127)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const 0x1.fffffep+127)) (f32.const 0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const inf)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const inf)) (f32.const 0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.921fb6p+2) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.921fb6p+2) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x0p+0)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x0p+0)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x1p-149)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x1p-149)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x1p-126)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x1p-126)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x1p-126)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x1p-1)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x1p-1)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x1p-1)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x1p+0)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x1p+0)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x1p+0)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x1.921fb6p+2)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x1.921fb6p+2)) (f32.const 0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const 0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const 0x1.fffffep+127)) (f32.const 0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const inf)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const inf)) (f32.const 0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -0x1.fffffep+127) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const 0x1.fffffep+127) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x0p+0)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x0p+0)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x0p+0)) (f32.const -0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x0p+0)) (f32.const 0x0p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x1p-149)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x1p-149)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x1p-149)) (f32.const -0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x1p-149)) (f32.const 0x1p-149))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x1p-126)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x1p-126)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x1p-126)) (f32.const -0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x1p-126)) (f32.const 0x1p-126))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x1p-1)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x1p-1)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x1p-1)) (f32.const -0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x1p-1)) (f32.const 0x1p-1))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x1p+0)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x1p+0)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x1p+0)) (f32.const -0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x1p+0)) (f32.const 0x1p+0))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x1.921fb6p+2)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x1.921fb6p+2)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x1.921fb6p+2)) (f32.const 0x1.921fb6p+2))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -0x1.fffffep+127)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const 0x1.fffffep+127)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+		
+		(if (f32.ne (call $min (f32.const inf) (f32.const 0x1.fffffep+127)) (f32.const 0x1.fffffep+127))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const -inf) (f32.const inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const -inf)) (f32.const -inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(if (f32.ne (call $min (f32.const inf) (f32.const inf)) (f32.const inf))(then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		;; (if (f32.ne (call $min (f32.const -inf) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -inf) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -inf) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -inf) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const inf) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const inf) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const inf) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const inf) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x0p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x0p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x0p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x0p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x0p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x0p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x0p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x0p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x1p-149)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x1p-149)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x1p-149)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x1p-149)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x1p-149)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x1p-149)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x1p-149)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x1p-149)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x1p-126)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x1p-126)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x1p-126)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x1p-126)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x1p-126)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x1p-126)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x1p-126)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x1p-126)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x1p-1)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x1p-1)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x1p-1)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x1p-1)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x1p-1)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x1p-1)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x1p-1)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x1p-1)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x1p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x1p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x1p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x1p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x1p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x1p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x1p+0)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x1p+0)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x1.921fb6p+2)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x1.921fb6p+2)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x1.921fb6p+2)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x1.921fb6p+2)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x1.921fb6p+2)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x1.921fb6p+2)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x1.921fb6p+2)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x1.921fb6p+2)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -0x1.fffffep+127)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -0x1.fffffep+127)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const 0x1.fffffep+127)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const 0x1.fffffep+127)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -0x1.fffffep+127)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -0x1.fffffep+127)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const 0x1.fffffep+127)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const 0x1.fffffep+127)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -inf)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -inf)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const inf)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const inf)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -inf)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -inf)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const inf)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const inf)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -nan)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const nan)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const -nan:0x200000) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -nan)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const -nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const nan)) (f32.const nan:canonical))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const nan)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		;; (if (f32.ne (call $min (f32.const nan:0x200000) (f32.const nan:0x200000)) (f32.const nan:arithmetic))(then     
+		;; 	(call $proc_exit (i32.const 1))
+		;; ))
+
+		(call $proc_exit (i32.const 0))
+
+	)
+)


### PR DESCRIPTION
This PR just ports some of the wasm tests for the f32.min instruction. My motivation was looking into replacing `f32_floor` with the LLVM intrinsic `llvm.floor.f32`. However, the compiler seems to struggle to compile with this intrinsic. Errors are below and above my head.

```
warning: overriding the module target triple with x86_64-pc-linux-gnu [-Woverride-module]
1 warning generated.
LLVM ERROR: Cannot select: 0x5612c58e27e0: f32 = fminimum 0x5612c58e29e8, 0x5612c58da608
  0x5612c58e29e8: f32,ch = CopyFromReg 0x5612c57068f8, Register:f32 %2
    0x5612c58e2570: f32 = Register %2
  0x5612c58da608: f32,ch = CopyFromReg 0x5612c57068f8, Register:f32 %4
    0x5612c58e2a50: f32 = Register %4
In function: wasmf_min
clang: error: unable to execute command: Aborted
clang: error: linker command failed due to signal (use -v to see invocation)
```

In any case, adding just the tests, which pass with the existing C implementation. The `wat2wasm` tool seems to be unable to compile nans for whatever reason, so those are commented out.