### PR TITLE
fix: Set cap to max pages by default

### DIFF
--- a/runtime/memory/64bit_nix.c
+++ b/runtime/memory/64bit_nix.c
@@ -24,8 +24,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size / WASM_PAGE_SIZE < max_pages));
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
     // Remap the relevant wasm page to readable
     char* mem_as_chars = memory;
     char* page_address = &mem_as_chars[memory_size];

--- a/runtime/memory/cortex_m.c
+++ b/runtime/memory/cortex_m.c
@@ -22,8 +22,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE));
+    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
 
     //    printf_("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));

--- a/runtime/memory/cortex_m.c
+++ b/runtime/memory/cortex_m.c
@@ -22,7 +22,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     //    printf_("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));

--- a/runtime/memory/cortex_m_no_protection.c
+++ b/runtime/memory/cortex_m_no_protection.c
@@ -23,7 +23,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     //    printf_("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));

--- a/runtime/memory/cortex_m_no_protection.c
+++ b/runtime/memory/cortex_m_no_protection.c
@@ -23,8 +23,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE));
+    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
 
     //    printf_("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));

--- a/runtime/memory/cortex_m_spt.c
+++ b/runtime/memory/cortex_m_spt.c
@@ -35,7 +35,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));
 
     char* mem_as_chars = memory;

--- a/runtime/memory/cortex_m_spt.c
+++ b/runtime/memory/cortex_m_spt.c
@@ -35,8 +35,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE));
+    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));
 
     char* mem_as_chars = memory;

--- a/runtime/memory/cortex_m_wrapping.c
+++ b/runtime/memory/cortex_m_wrapping.c
@@ -18,8 +18,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE));
+    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
 
     //    printf_("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));

--- a/runtime/memory/cortex_m_wrapping.c
+++ b/runtime/memory/cortex_m_wrapping.c
@@ -18,7 +18,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    awsm_assert(memory_size + WASM_PAGE_SIZE <= max_pages * WASM_PAGE_SIZE);
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     //    printf_("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory_size + WASM_PAGE_SIZE <= sizeof(CORTEX_M_MEM));

--- a/runtime/memory/generic.c
+++ b/runtime/memory/generic.c
@@ -9,8 +9,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size / WASM_PAGE_SIZE < max_pages));
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     printf("Expanding to %d\n", memory_size + WASM_PAGE_SIZE);
 

--- a/runtime/memory/mpx.c
+++ b/runtime/memory/mpx.c
@@ -12,8 +12,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size / WASM_PAGE_SIZE < max_pages));
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     memory = realloc(memory, memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory);

--- a/runtime/memory/no_protection.c
+++ b/runtime/memory/no_protection.c
@@ -9,8 +9,7 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
-    awsm_assert(max_pages == 0 || (memory_size / WASM_PAGE_SIZE < max_pages));
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     memory = realloc(memory, memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory);

--- a/runtime/memory/segmented.c
+++ b/runtime/memory/segmented.c
@@ -60,9 +60,8 @@ void alloc_linear_memory() {
 }
 
 void expand_memory() {
-    // max_pages = 0 => no limit
     reset_seg_registers();
-    awsm_assert(max_pages == 0 || (memory_size / WASM_PAGE_SIZE < max_pages));
+    awsm_assert(memory_size / WASM_PAGE_SIZE < max_pages);
 
     memory = realloc(memory, memory_size + WASM_PAGE_SIZE);
     awsm_assert(memory);

--- a/src/codegen/memory.rs
+++ b/src/codegen/memory.rs
@@ -17,7 +17,8 @@ use crate::codegen::function::compile_function;
 use crate::codegen::type_conversions::wasm_func_type_to_llvm_type;
 use crate::codegen::ModuleCtx;
 
-const MAX_WEBASSEMBLY_PAGES: u32 = 65536;
+// https://webassembly.github.io/spec/core/valid/types.html#memory-types
+const MAX_WEBASSEMBLY_PAGES: u32 = u32::pow(2, 16);
 
 // We add in globals to tell the runtime how much memory to allocate and startup
 // (And what the max amount of allocated memory should be)

--- a/src/codegen/memory.rs
+++ b/src/codegen/memory.rs
@@ -17,6 +17,8 @@ use crate::codegen::function::compile_function;
 use crate::codegen::type_conversions::wasm_func_type_to_llvm_type;
 use crate::codegen::ModuleCtx;
 
+const MAX_WEBASSEMBLY_PAGES: u32 = 65536;
+
 // We add in globals to tell the runtime how much memory to allocate and startup
 // (And what the max amount of allocated memory should be)
 pub fn add_memory_size_globals(ctx: &ModuleCtx, limits: &ResizableLimits) {
@@ -26,7 +28,7 @@ pub fn add_memory_size_globals(ctx: &ModuleCtx, limits: &ResizableLimits) {
         .add_global_variable("starting_pages", limits.initial.compile(ctx.llvm_ctx));
     starting_pages_global.set_constant(true);
 
-    let maximum: u32 = limits.maximum.unwrap_or(65536);
+    let maximum: u32 = limits.maximum.unwrap_or(MAX_WEBASSEMBLY_PAGES);
     let max_pages_global = ctx
         .llvm_module
         .add_global_variable("max_pages", maximum.compile(ctx.llvm_ctx));

--- a/src/codegen/memory.rs
+++ b/src/codegen/memory.rs
@@ -26,7 +26,7 @@ pub fn add_memory_size_globals(ctx: &ModuleCtx, limits: &ResizableLimits) {
         .add_global_variable("starting_pages", limits.initial.compile(ctx.llvm_ctx));
     starting_pages_global.set_constant(true);
 
-    let maximum: u32 = limits.maximum.unwrap_or(0);
+    let maximum: u32 = limits.maximum.unwrap_or(65536);
     let max_pages_global = ctx
         .llvm_module
         .add_global_variable("max_pages", maximum.compile(ctx.llvm_ctx));


### PR DESCRIPTION
We've started to use the `max_pages` global in SLEdge to enforce how large a linear memory should be able to grow. If unspecificed, I believe that the default should be "no cap," which we can achieve by defaulting to the largest possible number of WebAssembly pages.