### PR TITLE
chore: Silence WASI Unimplemented Errors by default

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Clang Format
-        run: find runtime example_code -type f -print | grep -v runtime/libuv | grep -v runtime/uvwasi | grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format -Werror -n -ferror-limit=0
+        run: |
+          sudo apt install clang-format-12 --yes
+          find runtime example_code -type f -print | grep -v runtime/libuv | grep -v runtime/uvwasi | grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-12 -Werror -n -ferror-limit=0
       - name: Cargo Format
         run: cargo fmt -- --check
 

--- a/format.sh
+++ b/format.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 utility="clang-format"
-utility_version="$("$utility" --version 2> /dev/null)" || {
+utility_version="$("$utility" --version 2>/dev/null)" || {
 	echo "$utility not found in path!"
 	exit 1
 }
@@ -29,9 +29,9 @@ fi
 # And format them with clang-format
 # Match all *.c, *.h, *.ld, and *.s files in runtime and example_code
 # And format them with clang-format
-find runtime example_code -type f -print \
-	| grep -v runtime/libuv \
-	| grep -v runtime/uvwasi \
-	| grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format -i
+find runtime example_code -type f -print |
+	grep -v runtime/libuv |
+	grep -v runtime/uvwasi |
+	grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-12 -i
 
 cargo fmt

--- a/runtime/libc/wasi/include/wasi_impl.h
+++ b/runtime/libc/wasi/include/wasi_impl.h
@@ -30,7 +30,7 @@ __wasi_size_t wasi_context_get_envc(void* wasi_context);
 __wasi_size_t wasi_context_get_env_buf_size(void* wasi_context);
 
 static inline __wasi_errno_t wasi_unsupported_syscall(const char* syscall) {
-#ifdef LOG_UNSUPPORTED_WASI
+#ifndef NDEBUG
     fprintf(stderr, "Syscall %s is not supported\n", syscall);
 #endif
     return __WASI_ERRNO_NOTSUP;

--- a/runtime/libc/wasi/include/wasi_impl.h
+++ b/runtime/libc/wasi/include/wasi_impl.h
@@ -30,6 +30,8 @@ __wasi_size_t wasi_context_get_envc(void* wasi_context);
 __wasi_size_t wasi_context_get_env_buf_size(void* wasi_context);
 
 static inline __wasi_errno_t wasi_unsupported_syscall(const char* syscall) {
+#ifdef LOG_UNSUPPORTED_WASI
     fprintf(stderr, "Syscall %s is not supported\n", syscall);
+#endif
     return __WASI_ERRNO_NOTSUP;
 }


### PR DESCRIPTION
We likely will have to run perf testing before all WASI syscalls are implemented, so we should silence these warnings unless told otherwise.