### PR TITLE
fix: WASI FD namespacing

### DIFF
--- a/runtime/libc/wasi/include/wasi_backing.h
+++ b/runtime/libc/wasi/include/wasi_backing.h
@@ -48,7 +48,7 @@ uint32_t wasi_snapshot_preview1_args_get(__wasi_size_t argv_retoffset, __wasi_si
     }
 
     __wasi_size_t*      argv_retptr     = (__wasi_size_t*)get_memory_ptr_for_runtime(argv_retoffset,
-                                                                            WASI_SERDES_SIZE_size_t * argc);
+                                                                                     WASI_SERDES_SIZE_size_t * argc);
     const __wasi_size_t argv_buf_size   = wasi_context_get_argv_buf_size(CURRENT_WASI_CONTEXT);
     char*               argv_buf_retptr = get_memory_ptr_for_runtime(argv_buf_retoffset, argv_buf_size);
 
@@ -158,7 +158,7 @@ uint32_t wasi_snapshot_preview1_environ_get(__wasi_size_t env_retoffset, __wasi_
     }
 
     __wasi_size_t* env_retptr     = (__wasi_size_t*)get_memory_ptr_for_runtime(env_retoffset,
-                                                                           WASI_SERDES_SIZE_size_t * envc);
+                                                                               WASI_SERDES_SIZE_size_t * envc);
     char*          env_buf_retptr = get_memory_ptr_for_runtime(env_buf_retoffset, env_buf_size);
 
     rc = wasi_snapshot_preview1_backing_environ_get(CURRENT_WASI_CONTEXT, env_temp, env_buf_retptr);
@@ -287,7 +287,7 @@ uint32_t wasi_snapshot_preview1_fd_fdstat_set_flags(__wasi_fd_t fd, uint32_t fdf
     }
     __wasi_fdflags_t fdflags = (__wasi_fdflags_t)fdflags_extended;
 
-    rc = wasi_snapshot_preview1_backing_fdstat_set_flags(CURRENT_WASI_CONTEXT, fd, fdflags);
+    rc = wasi_snapshot_preview1_backing_fd_fdstat_set_flags(CURRENT_WASI_CONTEXT, fd, fdflags);
 
 done:
     return (uint32_t)rc;
@@ -305,8 +305,8 @@ done:
  */
 uint32_t wasi_snapshot_preview1_fd_fdstat_set_rights(__wasi_fd_t fd, __wasi_rights_t fs_rights_base,
                                                      __wasi_rights_t fs_rights_inheriting) {
-    return (uint32_t)wasi_snapshot_preview1_backing_fdstat_set_rights(CURRENT_WASI_CONTEXT, fd, fs_rights_base,
-                                                                      fs_rights_inheriting);
+    return (uint32_t)wasi_snapshot_preview1_backing_fd_fdstat_set_rights(CURRENT_WASI_CONTEXT, fd, fs_rights_base,
+                                                                         fs_rights_inheriting);
 }
 
 /**
@@ -354,7 +354,7 @@ uint32_t wasi_snapshot_preview1_fd_filestat_set_times(__wasi_fd_t fd, __wasi_tim
     }
     __wasi_fstflags_t fstflags = (__wasi_fstflags_t)fstflags_extended;
 
-    rc = wasi_snapshot_preview1_backing_filestat_set_times(CURRENT_WASI_CONTEXT, fd, atim, mtim, fstflags);
+    rc = wasi_snapshot_preview1_backing_fd_filestat_set_times(CURRENT_WASI_CONTEXT, fd, atim, mtim, fstflags);
 
 done:
     return (uint32_t)rc;
@@ -894,10 +894,10 @@ uint32_t wasi_snapshot_preview1_poll_oneoff(__wasi_size_t in_baseoffset, __wasi_
     const __wasi_subscription_t* in_baseptr = (const __wasi_subscription_t*)
       get_memory_ptr_for_runtime(in_baseoffset, WASI_SERDES_SIZE_subscription_t * nsubscriptions);
     __wasi_event_t* out_baseptr    = (__wasi_event_t*)get_memory_ptr_for_runtime(out_baseoffset,
-                                                                              WASI_SERDES_SIZE_subscription_t
-                                                                                * nsubscriptions);
+                                                                                 WASI_SERDES_SIZE_subscription_t
+                                                                                   * nsubscriptions);
     __wasi_size_t*  nevents_retptr = (__wasi_size_t*)get_memory_ptr_for_runtime(nevents_retoffset,
-                                                                               WASI_SERDES_SIZE_size_t);
+                                                                                WASI_SERDES_SIZE_size_t);
 
     return (uint32_t)wasi_snapshot_preview1_backing_poll_oneoff(CURRENT_WASI_CONTEXT, in_baseptr, out_baseptr,
                                                                 nsubscriptions, nevents_retptr);

--- a/runtime/libc/wasi/include/wasi_backing.h
+++ b/runtime/libc/wasi/include/wasi_backing.h
@@ -48,7 +48,7 @@ uint32_t wasi_snapshot_preview1_args_get(__wasi_size_t argv_retoffset, __wasi_si
     }
 
     __wasi_size_t*      argv_retptr     = (__wasi_size_t*)get_memory_ptr_for_runtime(argv_retoffset,
-                                                                                     WASI_SERDES_SIZE_size_t * argc);
+                                                                            WASI_SERDES_SIZE_size_t * argc);
     const __wasi_size_t argv_buf_size   = wasi_context_get_argv_buf_size(CURRENT_WASI_CONTEXT);
     char*               argv_buf_retptr = get_memory_ptr_for_runtime(argv_buf_retoffset, argv_buf_size);
 
@@ -158,7 +158,7 @@ uint32_t wasi_snapshot_preview1_environ_get(__wasi_size_t env_retoffset, __wasi_
     }
 
     __wasi_size_t* env_retptr     = (__wasi_size_t*)get_memory_ptr_for_runtime(env_retoffset,
-                                                                               WASI_SERDES_SIZE_size_t * envc);
+                                                                           WASI_SERDES_SIZE_size_t * envc);
     char*          env_buf_retptr = get_memory_ptr_for_runtime(env_buf_retoffset, env_buf_size);
 
     rc = wasi_snapshot_preview1_backing_environ_get(CURRENT_WASI_CONTEXT, env_temp, env_buf_retptr);
@@ -894,10 +894,10 @@ uint32_t wasi_snapshot_preview1_poll_oneoff(__wasi_size_t in_baseoffset, __wasi_
     const __wasi_subscription_t* in_baseptr = (const __wasi_subscription_t*)
       get_memory_ptr_for_runtime(in_baseoffset, WASI_SERDES_SIZE_subscription_t * nsubscriptions);
     __wasi_event_t* out_baseptr    = (__wasi_event_t*)get_memory_ptr_for_runtime(out_baseoffset,
-                                                                                 WASI_SERDES_SIZE_subscription_t
-                                                                                   * nsubscriptions);
+                                                                              WASI_SERDES_SIZE_subscription_t
+                                                                                * nsubscriptions);
     __wasi_size_t*  nevents_retptr = (__wasi_size_t*)get_memory_ptr_for_runtime(nevents_retoffset,
-                                                                                WASI_SERDES_SIZE_size_t);
+                                                                               WASI_SERDES_SIZE_size_t);
 
     return (uint32_t)wasi_snapshot_preview1_backing_poll_oneoff(CURRENT_WASI_CONTEXT, in_baseptr, out_baseptr,
                                                                 nsubscriptions, nevents_retptr);

--- a/runtime/libc/wasi/include/wasi_spec.h
+++ b/runtime/libc/wasi/include/wasi_spec.h
@@ -1707,22 +1707,22 @@ wasi_snapshot_preview1_backing_fd_fdstat_get(void* wasi_context, __wasi_fd_t fd,
  * Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
  */
 __wasi_errno_t
-wasi_snapshot_preview1_backing_fdstat_set_flags(void* wasi_context, __wasi_fd_t fd,
-                                                /**
-                                                 * The desired values of the file descriptor flags.
-                                                 */
-                                                __wasi_fdflags_t flags) __attribute__((__warn_unused_result__));
+wasi_snapshot_preview1_backing_fd_fdstat_set_flags(void* wasi_context, __wasi_fd_t fd,
+                                                   /**
+                                                    * The desired values of the file descriptor flags.
+                                                    */
+                                                   __wasi_fdflags_t flags) __attribute__((__warn_unused_result__));
 /**
  * Adjust the rights associated with a file descriptor.
  * This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add
  * rights
  */
-__wasi_errno_t
-wasi_snapshot_preview1_backing_fdstat_set_rights(void* wasi_context, __wasi_fd_t fd,
-                                                 /**
-                                                  * The desired rights of the file descriptor.
-                                                  */
-                                                 __wasi_rights_t fs_rights_base, __wasi_rights_t fs_rights_inheriting)
+__wasi_errno_t wasi_snapshot_preview1_backing_fd_fdstat_set_rights(void* wasi_context, __wasi_fd_t fd,
+                                                                   /**
+                                                                    * The desired rights of the file descriptor.
+                                                                    */
+                                                                   __wasi_rights_t fs_rights_base,
+                                                                   __wasi_rights_t fs_rights_inheriting)
   __attribute__((__warn_unused_result__));
 /**
  * Return the attributes of an open file.
@@ -1747,19 +1747,20 @@ wasi_snapshot_preview1_backing_fd_filestat_set_size(void* wasi_context, __wasi_f
  * Note: This is similar to `futimens` in POSIX.
  */
 __wasi_errno_t
-wasi_snapshot_preview1_backing_filestat_set_times(void* wasi_context, __wasi_fd_t fd,
-                                                  /**
-                                                   * The desired values of the data access timestamp.
-                                                   */
-                                                  __wasi_timestamp_t atim,
-                                                  /**
-                                                   * The desired values of the data modification timestamp.
-                                                   */
-                                                  __wasi_timestamp_t mtim,
-                                                  /**
-                                                   * A bitmask indicating which timestamps to adjust.
-                                                   */
-                                                  __wasi_fstflags_t fst_flags) __attribute__((__warn_unused_result__));
+wasi_snapshot_preview1_backing_fd_filestat_set_times(void* wasi_context, __wasi_fd_t fd,
+                                                     /**
+                                                      * The desired values of the data access timestamp.
+                                                      */
+                                                     __wasi_timestamp_t atim,
+                                                     /**
+                                                      * The desired values of the data modification timestamp.
+                                                      */
+                                                     __wasi_timestamp_t mtim,
+                                                     /**
+                                                      * A bitmask indicating which timestamps to adjust.
+                                                      */
+                                                     __wasi_fstflags_t fst_flags)
+  __attribute__((__warn_unused_result__));
 /**
  * Read from a file descriptor, without using and updating the file descriptor's offset.
  * Note: This is similar to `preadv` in POSIX.

--- a/runtime/libc/wasi/wasi_impl_minimal.c
+++ b/runtime/libc/wasi/wasi_impl_minimal.c
@@ -500,7 +500,7 @@ wasi_snapshot_preview1_backing_fd_fdstat_get(void* wasi_context, __wasi_fd_t fd,
  * WASI_EPERM
  */
 __wasi_errno_t
-wasi_snapshot_preview1_backing_fdstat_set_flags(void* wasi_context, __wasi_fd_t fd, __wasi_fdflags_t fdflags) {
+wasi_snapshot_preview1_backing_fd_fdstat_set_flags(void* wasi_context, __wasi_fd_t fd, __wasi_fdflags_t fdflags) {
     /* TODO: Sandbox fd in context */
 
     int flags = (((flags & __WASI_FDFLAGS_APPEND) ? O_APPEND : 0) | ((flags & __WASI_FDFLAGS_DSYNC) ? O_DSYNC : 0)
@@ -524,8 +524,8 @@ wasi_snapshot_preview1_backing_fdstat_set_flags(void* wasi_context, __wasi_fd_t 
  * @return status code
  */
 __wasi_errno_t
-wasi_snapshot_preview1_backing_fdstat_set_rights(void* wasi_context, __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
-                                                 __wasi_rights_t fs_rights_inheriting) {
+wasi_snapshot_preview1_backing_fd_fdstat_set_rights(void* wasi_context, __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
+                                                    __wasi_rights_t fs_rights_inheriting) {
     return wasi_unsupported_syscall(__func__);
 }
 
@@ -565,8 +565,8 @@ wasi_snapshot_preview1_backing_fd_filestat_set_size(void* wasi_context, __wasi_f
  * @return status code
  */
 __wasi_errno_t
-wasi_snapshot_preview1_backing_filestat_set_times(void* wasi_context, __wasi_fd_t fd, __wasi_timestamp_t atim,
-                                                  __wasi_timestamp_t mtim, __wasi_fstflags_t fst_flags) {
+wasi_snapshot_preview1_backing_fd_filestat_set_times(void* wasi_context, __wasi_fd_t fd, __wasi_timestamp_t atim,
+                                                     __wasi_timestamp_t mtim, __wasi_fstflags_t fst_flags) {
     /* similar to `futimens` in POSIX. */
     return wasi_unsupported_syscall(__func__);
 }

--- a/runtime/libc/wasi/wasi_impl_uvwasi.c
+++ b/runtime/libc/wasi/wasi_impl_uvwasi.c
@@ -159,13 +159,13 @@ wasi_snapshot_preview1_backing_fd_fdstat_get(void* wasi_context, __wasi_fd_t fd,
 }
 
 __wasi_errno_t
-wasi_snapshot_preview1_backing_fdstat_set_flags(void* wasi_context, __wasi_fd_t fd, __wasi_fdflags_t flags) {
+wasi_snapshot_preview1_backing_fd_fdstat_set_flags(void* wasi_context, __wasi_fd_t fd, __wasi_fdflags_t flags) {
     return uvwasi_fd_fdstat_set_flags((uvwasi_t*)wasi_context, fd, flags);
 }
 
 __wasi_errno_t
-wasi_snapshot_preview1_backing_fdstat_set_rights(void* wasi_context, __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
-                                                 __wasi_rights_t fs_rights_inheriting) {
+wasi_snapshot_preview1_backing_fd_fdstat_set_rights(void* wasi_context, __wasi_fd_t fd, __wasi_rights_t fs_rights_base,
+                                                    __wasi_rights_t fs_rights_inheriting) {
     return uvwasi_fd_fdstat_set_rights((uvwasi_t*)wasi_context, fd, fs_rights_base, fs_rights_inheriting);
 }
 
@@ -180,8 +180,8 @@ wasi_snapshot_preview1_backing_fd_filestat_set_size(void* wasi_context, __wasi_f
 }
 
 __wasi_errno_t
-wasi_snapshot_preview1_backing_filestat_set_times(void* wasi_context, __wasi_fd_t fd, __wasi_timestamp_t atim,
-                                                  __wasi_timestamp_t mtim, __wasi_fstflags_t fst_flags) {
+wasi_snapshot_preview1_backing_fd_filestat_set_times(void* wasi_context, __wasi_fd_t fd, __wasi_timestamp_t atim,
+                                                     __wasi_timestamp_t mtim, __wasi_fstflags_t fst_flags) {
     return uvwasi_fd_filestat_set_times((uvwasi_t*)wasi_context, fd, atim, mtim, fst_flags);
 }
 


### PR DESCRIPTION
When I created the ABI documentation, I noticed that some of the WASI symbols were wrong. This should fix them.

The format issue should be resolved by merging #82 