### PR TITLE
feat: globals_len

### DIFF
--- a/src/codegen/globals.rs
+++ b/src/codegen/globals.rs
@@ -71,6 +71,12 @@ pub fn insert_globals<'a>(
     }
 }
 
+fn write_globals_len<'a>(llvm_ctx: &'a LLVMCtx, llvm_module: &'a LLVMModule, globals_len: u32) {
+    let max_pages_global =
+        llvm_module.add_global_variable("globals_len", globals_len.compile(llvm_ctx));
+    max_pages_global.set_constant(true);
+}
+
 fn insert_native_globals<'a>(
     opt: &Opt,
     llvm_ctx: &'a LLVMCtx,
@@ -108,6 +114,9 @@ fn insert_native_globals<'a>(
         };
         global_values.push(v);
     }
+
+    write_globals_len(&*llvm_ctx, &*llvm_module, 0);
+
     global_values
 }
 
@@ -159,6 +168,8 @@ fn insert_runtime_globals<'a>(
         global_values.push(v);
     }
     b.build_ret_void();
+
+    write_globals_len(&*llvm_ctx, &*llvm_module, global_values.len() as u32);
 
     global_values
 }

--- a/src/codegen/globals.rs
+++ b/src/codegen/globals.rs
@@ -71,12 +71,6 @@ pub fn insert_globals<'a>(
     }
 }
 
-fn write_globals_len<'a>(llvm_ctx: &'a LLVMCtx, llvm_module: &'a LLVMModule, globals_len: u32) {
-    let max_pages_global =
-        llvm_module.add_global_variable("globals_len", globals_len.compile(llvm_ctx));
-    max_pages_global.set_constant(true);
-}
-
 fn insert_native_globals<'a>(
     opt: &Opt,
     llvm_ctx: &'a LLVMCtx,
@@ -172,6 +166,12 @@ fn insert_runtime_globals<'a>(
     write_globals_len(&*llvm_ctx, &*llvm_module, global_values.len() as u32);
 
     global_values
+}
+
+fn write_globals_len<'a>(llvm_ctx: &'a LLVMCtx, llvm_module: &'a LLVMModule, globals_len: u32) {
+    let max_pages_global =
+        llvm_module.add_global_variable("globals_len", globals_len.compile(llvm_ctx));
+    max_pages_global.set_constant(true);
 }
 
 fn initializer_to_value<'a>(

--- a/tests/wat/globals.wat
+++ b/tests/wat/globals.wat
@@ -1,4 +1,5 @@
 (module
+	(import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
 	(memory 1)
 	(global i32 (i32.const 4))
 	(global i32 (i32.const 8))
@@ -6,4 +7,34 @@
 	(global i32 (i32.const 16))
 	(global i32 (i32.const 23))
 	(global i32 (i32.const 42))
+
+	(func $_start (export "_start")
+		(global.set (i32.const 0) (i32.mul (global.get 0) (i32.const 2)))
+		(global.set (i32.const 1) (i32.mul (global.get 1) (i32.const 2)))
+		(global.set (i32.const 2) (i32.mul (global.get 2) (i32.const 2)))
+		(global.set (i32.const 3) (i32.mul (global.get 3) (i32.const 2)))
+		(global.set (i32.const 4) (i32.mul (global.get 4) (i32.const 2)))
+		(global.set (i32.const 5) (i32.mul (global.get 5) (i32.const 2)))
+
+		(if (i32.ne (global.get (i32.const 0)) (i32.const 8)) (then     
+			(call $proc_exit (i32.const 1))
+		))
+		(if (i32.ne (global.get (i32.const 1)) (i32.const 16)) (then     
+			(call $proc_exit (i32.const 1))
+		))
+		(if (i32.ne (global.get (i32.const 2)) (i32.const 30)) (then     
+			(call $proc_exit (i32.const 1))
+		))
+		(if (i32.ne (global.get (i32.const 3)) (i32.const 32)) (then     
+			(call $proc_exit (i32.const 1))
+		))
+		(if (i32.ne (global.get (i32.const 4)) (i32.const 46)) (then     
+			(call $proc_exit (i32.const 1))
+		))
+		(if (i32.ne (global.get (i32.const 5)) (i32.const 84)) (then     
+			(call $proc_exit (i32.const 1))
+		))
+
+		(call $proc_exit (i32.const 0))
+	)
 )

--- a/tests/wat/globals.wat
+++ b/tests/wat/globals.wat
@@ -1,37 +1,37 @@
 (module
 	(import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
 	(memory 1)
-	(global i32 (i32.const 4))
-	(global i32 (i32.const 8))
-	(global i32 (i32.const 15))
-	(global i32 (i32.const 16))
-	(global i32 (i32.const 23))
-	(global i32 (i32.const 42))
+	(global (mut i32) (i32.const 4))
+	(global (mut i32) (i32.const 8))
+	(global (mut i32) (i32.const 15))
+	(global (mut i32) (i32.const 16))
+	(global (mut i32) (i32.const 23))
+	(global (mut i32) (i32.const 42))
 
 	(func $_start (export "_start")
-		(global.set (i32.const 0) (i32.mul (global.get 0) (i32.const 2)))
-		(global.set (i32.const 1) (i32.mul (global.get 1) (i32.const 2)))
-		(global.set (i32.const 2) (i32.mul (global.get 2) (i32.const 2)))
-		(global.set (i32.const 3) (i32.mul (global.get 3) (i32.const 2)))
-		(global.set (i32.const 4) (i32.mul (global.get 4) (i32.const 2)))
-		(global.set (i32.const 5) (i32.mul (global.get 5) (i32.const 2)))
+		(global.set 0 (i32.mul (global.get 0) (i32.const 2)))
+		(global.set 1 (i32.mul (global.get 1) (i32.const 2)))
+		(global.set 2 (i32.mul (global.get 2) (i32.const 2)))
+		(global.set 3 (i32.mul (global.get 3) (i32.const 2)))
+		(global.set 4 (i32.mul (global.get 4) (i32.const 2)))
+		(global.set 5 (i32.mul (global.get 5) (i32.const 2)))
 
-		(if (i32.ne (global.get (i32.const 0)) (i32.const 8)) (then     
+		(if (i32.ne (global.get 0) (i32.const 8)) (then     
 			(call $proc_exit (i32.const 1))
 		))
-		(if (i32.ne (global.get (i32.const 1)) (i32.const 16)) (then     
+		(if (i32.ne (global.get 1) (i32.const 16)) (then     
 			(call $proc_exit (i32.const 1))
 		))
-		(if (i32.ne (global.get (i32.const 2)) (i32.const 30)) (then     
+		(if (i32.ne (global.get 2) (i32.const 30)) (then     
 			(call $proc_exit (i32.const 1))
 		))
-		(if (i32.ne (global.get (i32.const 3)) (i32.const 32)) (then     
+		(if (i32.ne (global.get 3) (i32.const 32)) (then     
 			(call $proc_exit (i32.const 1))
 		))
-		(if (i32.ne (global.get (i32.const 4)) (i32.const 46)) (then     
+		(if (i32.ne (global.get 4) (i32.const 46)) (then     
 			(call $proc_exit (i32.const 1))
 		))
-		(if (i32.ne (global.get (i32.const 5)) (i32.const 84)) (then     
+		(if (i32.ne (global.get 5) (i32.const 84)) (then     
 			(call $proc_exit (i32.const 1))
 		))
 

--- a/tests/wat/globals.wat
+++ b/tests/wat/globals.wat
@@ -1,0 +1,9 @@
+(module
+	(memory 1)
+	(global i32 (i32.const 4))
+	(global i32 (i32.const 8))
+	(global i32 (i32.const 15))
+	(global i32 (i32.const 16))
+	(global i32 (i32.const 23))
+	(global i32 (i32.const 42))
+)


### PR DESCRIPTION
When using `--runtime-globals`, a runtime needs to be able to know the size of vector it should allocate to store the globals.

With runtime globals on:

```wasm
@globals_len = constant i32 6
define void @populate_globals() {
root:
  call void @set_global_i32(i32 0, i32 4)
  call void @set_global_i32(i32 1, i32 8)
  call void @set_global_i32(i32 2, i32 15)
  call void @set_global_i32(i32 3, i32 16)
  call void @set_global_i32(i32 4, i32 23)
  call void @set_global_i32(i32 5, i32 42)
  ret void
}
```

With runtime globals off:

```wasm
@wasmg_internal_0 = constant i32 4
@wasmg_internal_1 = constant i32 8
@wasmg_internal_2 = constant i32 15
@wasmg_internal_3 = constant i32 16
@wasmg_internal_4 = constant i32 23
@wasmg_internal_5 = constant i32 42
@globals_len = constant i32 0
```