### PR TITLE
feat: Call runtime function on wasm unreachable instruction

### DIFF
--- a/applications/Makefile
+++ b/applications/Makefile
@@ -63,6 +63,9 @@ dist/leap.awsm: dist/leap.bc leap/main.c ${RUNTIME_PATH}/runtime.c ${RUNTIME_PAT
 dist/triangle.awsm: dist/triangle.bc triangle/main.c ${RUNTIME_PATH}/runtime.c ${RUNTIME_PATH}/memory/64bit_nix.c
 	${CC} -lm -O3 -flto $^ -o $@
 
+dist/unreachable.awsm: dist/unreachable.bc unreachable/main.c ${RUNTIME_PATH}/runtime.c ${RUNTIME_PATH}/memory/64bit_nix.c
+	${CC} -lm -O3 -flto $^ -o $@
+
 dist/%.awsm: dist/%.bc ${WASI_CPATH}
 	${CC} -pthread -ldl -lm -O3 -flto -g ${RUNTIME_INCLUDES} $^ -o $@
 

--- a/applications/unreachable/main.c
+++ b/applications/unreachable/main.c
@@ -1,0 +1,9 @@
+#include "../../runtime/runtime.h"
+
+IMPORT void wasmf_run(void);
+
+int main(int argc, char* argv[]) {
+    runtime_init();
+    wasmf_run();
+    return 0;
+}

--- a/doc/abi.md
+++ b/doc/abi.md
@@ -29,19 +29,19 @@ The two columns represent the state of the resulting LLVM bitcode when the "fast
 
 ### [Control Instructions](https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions)
 
-| instruction    | "fast unsafe" enabled              | "fast unsafe" disabled             |
-| -------------- | ---------------------------------- | ---------------------------------- |
-| block / end    | codegen                            | codegen                            |
-| br             | codegen                            | codegen                            |
-| br_if          | codegen                            | codegen                            |
-| br_table       | codegen                            | codegen                            |
-| call           | codegen                            | codegen                            |
-| call_indirect  | extern (`get_function_from_table`) | extern (`get_function_from_table`) |
-| if / else /end | codegen                            | codegen                            |
-| loop / end     | codegen                            | codegen                            |
-| nop            | codegen                            | codegen                            |
-| return         | codegen                            | codegen                            |
-| unreachable    | intrinsic ([llvm.trap][llvm-trap]) | intrinsic ([llvm.trap][llvm-trap]) |
+| instruction    | "fast unsafe" enabled                 | "fast unsafe" disabled                |
+| -------------- | ------------------------------------- | ------------------------------------- |
+| block / end    | codegen                               | codegen                               |
+| br             | codegen                               | codegen                               |
+| br_if          | codegen                               | codegen                               |
+| br_table       | codegen                               | codegen                               |
+| call           | codegen                               | codegen                               |
+| call_indirect  | extern (`get_function_from_table`)    | extern (`get_function_from_table`)    |
+| if / else /end | codegen                               | codegen                               |
+| loop / end     | codegen                               | codegen                               |
+| nop            | codegen                               | codegen                               |
+| return         | codegen                               | codegen                               |
+| unreachable    | extern (`awsm_abi__trap_unreachable`) | extern (`awsm_abi__trap_unreachable`) |
 
 ### [Reference instructions](https://webassembly.github.io/spec/core/syntax/instructions.html#reference-instructions)
 

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -280,7 +280,7 @@ INLINE double f64_copysign(double a, double b) {
     return copysign(a, b);
 }
 
-INLINE void awsm_abi__trap_unreachable() {
+__attribute__((noreturn)) void awsm_abi__trap_unreachable() {
     fprintf(stderr, "WebAssembly control flow unexpectedly reached unreachable instruction\n");
     exit(EXIT_FAILURE);
 }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -280,6 +280,11 @@ INLINE double f64_copysign(double a, double b) {
     return copysign(a, b);
 }
 
+INLINE void awsm_abi__trap_unreachable() {
+    fprintf(stderr, "WebAssembly control flow unexpectedly reached unreachable instruction\n");
+    exit(EXIT_FAILURE);
+}
+
 // We want to have some allocation logic here, so we can use it to implement libc
 WEAK u32 wasmg___heap_base = 0;
 u32      runtime_heap_base;

--- a/src/codegen/block.rs
+++ b/src/codegen/block.rs
@@ -356,7 +356,7 @@ pub fn compile_block<'a, 'b, 'c>(
                 block_terminated = true;
             }
             Instruction::Unreachable => {
-                let trap_call = get_stub_function(m_ctx, TRAP);
+                let trap_call = get_stub_function(m_ctx, TRAP_UNREACHABLE);
                 b.build_call(trap_call, &[]);
                 b.build_unreachable();
                 block_terminated = true;

--- a/src/codegen/runtime_stubs.rs
+++ b/src/codegen/runtime_stubs.rs
@@ -87,6 +87,8 @@ pub const F64_MAX: &str = "f64_max";
 pub const F64_MIN: &str = "f64_min";
 pub const F64_COPYSIGN: &str = "f64_copysign";
 
+pub const TRAP_UNREACHABLE: &str = "awsm_abi__trap_unreachable";
+
 // Intrinsic llvm functions
 pub const I32_CTPOP: &str = "llvm.ctpop.i32";
 pub const I64_CTPOP: &str = "llvm.ctpop.i64";
@@ -102,8 +104,6 @@ pub const F64_FABS: &str = "llvm.fabs.f64";
 
 pub const F32_SQRT: &str = "llvm.sqrt.f32";
 pub const F64_SQRT: &str = "llvm.sqrt.f64";
-
-pub const TRAP: &str = "llvm.trap";
 
 // TODO: Rewrite this using macros, because this is just gross
 pub fn insert_runtime_stubs(opt: &Opt, ctx: &LLVMCtx, m: &LLVMModule) {
@@ -455,7 +455,10 @@ pub fn insert_runtime_stubs(opt: &Opt, ctx: &LLVMCtx, m: &LLVMModule) {
         .to_super(),
     );
 
-    m.add_function(TRAP, FunctionType::new(<()>::get_type(ctx), &[]).to_super());
+    m.add_function(
+        TRAP_UNREACHABLE,
+        FunctionType::new(<()>::get_type(ctx), &[]).to_super(),
+    );
 }
 
 pub fn get_stub_function<'a>(m_ctx: &'a ModuleCtx, name: &str) -> &'a Function {


### PR DESCRIPTION
Adds a hook that I can use in SLEdge to prevent assertions within a sandbox from crashing the runtime.