### PR TITLE
Start section

### DIFF
--- a/applications/Makefile
+++ b/applications/Makefile
@@ -60,6 +60,9 @@ dist/binary-search.awsm: dist/binary-search.bc binary-search/main.c ${RUNTIME_PA
 dist/leap.awsm: dist/leap.bc leap/main.c ${RUNTIME_PATH}/runtime.c ${RUNTIME_PATH}/memory/64bit_nix.c
 	${CC} -lm -O3 -flto $^ -o $@
 
+dist/start.awsm: dist/start.bc start/main.c ${RUNTIME_PATH}/runtime.c ${RUNTIME_PATH}/memory/64bit_nix.c
+	${CC} -lm -O3 -flto $^ -o $@
+
 dist/triangle.awsm: dist/triangle.bc triangle/main.c ${RUNTIME_PATH}/runtime.c ${RUNTIME_PATH}/memory/64bit_nix.c
 	${CC} -lm -O3 -flto $^ -o $@
 

--- a/applications/start/main.c
+++ b/applications/start/main.c
@@ -1,0 +1,10 @@
+#include "../../runtime/runtime.h"
+
+IMPORT int wasmf_increment(void);
+
+int main(int argc, char* argv[]) {
+    runtime_init();
+
+    awsm_assert(wasmf_increment() == 43);
+    awsm_assert(wasmf_increment() == 44);
+}

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -328,5 +328,8 @@ void runtime_init() {
         runtime_heap_base = memory_size;
     }
 
+    // The start component of a module declares the function index of a start function that is automatically invoked
+    // when the module is instantiated, after tables and memories have been initialized.
+    // https://webassembly.github.io/spec/core/syntax/modules.html#start-function
     awsm_abi__start_fn();
 }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -304,6 +304,9 @@ void* allocate_n_bytes_ptr(u32 n) {
 // If we are using runtime globals, we need to populate them
 WEAK void populate_globals() {}
 
+// If a function is registered using the (start) instruction, call it
+WEAK void awsm_abi__start_fn() {}
+
 void runtime_init() {
     if (likely(starting_pages > 0)) {
         alloc_linear_memory();
@@ -324,4 +327,6 @@ void runtime_init() {
     if (runtime_heap_base == 0) {
         runtime_heap_base = memory_size;
     }
+
+    awsm_abi__start_fn();
 }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -4,9 +4,7 @@ use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use llvm::Builder;
-use llvm::Compile;
 use llvm::Function;
-use llvm::FunctionType;
 use llvm::Value;
 use llvm::{BasicBlock, Sub};
 
@@ -17,7 +15,6 @@ use crate::codegen::breakout::BreakoutTarget;
 use crate::codegen::type_conversions::wasm_type_to_zeroed_value;
 use crate::codegen::ModuleCtx;
 
-use crate::wasm::Function::Implemented;
 use crate::wasm::ImplementedFunction;
 
 pub struct FunctionCtx<'a> {
@@ -222,50 +219,6 @@ pub fn compile_function(ctx: &ModuleCtx, f: &ImplementedFunction) {
         Some(v) => builder.build_ret(v),
         None => builder.build_ret_void(),
     };
-}
-
-pub fn generate_start_stub(ctx: &ModuleCtx, start_fn_idx: Option<u32>) {
-    if let Some(idx) = start_fn_idx {
-        let (_, func) = &ctx.functions[idx as usize];
-
-        match func {
-            Implemented { f } => {
-                if let Some(start_function_type) = &f.ty {
-                    if start_function_type.params.len() > 0 {
-                        panic!("Expected start function to not take parameters");
-                    }
-                } else {
-                    panic!("Expected start function to have type");
-                }
-
-                let setup_function = ctx.llvm_module.add_function(
-                    "awsm_abi__start_fn",
-                    FunctionType::new(<()>::get_type(ctx.llvm_ctx), &[]).to_super(),
-                );
-                let bb = setup_function.append("entry");
-                let b = Builder::new(ctx.llvm_ctx);
-                b.position_at_end(bb);
-                b.build_call(
-                    ctx.llvm_module.get_function(&f.generated_name).unwrap(),
-                    &[],
-                );
-
-                b.build_ret_void();
-            }
-            _ => {
-                panic!("Expected start function to be locally implemented");
-            }
-        }
-    } else {
-        let setup_function = ctx.llvm_module.add_function(
-            "awsm_abi__start_fn",
-            FunctionType::new(<()>::get_type(ctx.llvm_ctx), &[]).to_super(),
-        );
-        let bb = setup_function.append("entry");
-        let b = Builder::new(ctx.llvm_ctx);
-        b.position_at_end(bb);
-        b.build_ret_void();
-    }
 }
 
 // NOTE: Handle loop at the call site by inserting phi instructions immediately

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -20,7 +20,9 @@ mod breakout;
 
 mod function;
 use self::function::compile_function;
-use self::function::generate_start_stub;
+
+mod start;
+use self::start::generate_start_stub;
 
 mod globals;
 use self::globals::insert_globals;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -19,6 +19,7 @@ mod breakout;
 
 mod function;
 use self::function::compile_function;
+use self::function::generate_start_stub;
 
 mod globals;
 use self::globals::insert_globals;
@@ -110,6 +111,8 @@ pub fn process_to_llvm(
 
     // Which we then need to initialize the data
     generate_memory_initialization_stub(&module_ctx, wasm_module.data_initializers);
+
+    generate_start_stub(&module_ctx, wasm_module.start_function);
 
     if wasm_module.tables.len() > 0 {
         // Assume there is at most one relevant table

--- a/src/codegen/start.rs
+++ b/src/codegen/start.rs
@@ -1,0 +1,57 @@
+use crate::codegen::ModuleCtx;
+use crate::wasm::Function::Implemented;
+use llvm::Builder;
+use llvm::FunctionType;
+use llvm::Sub;
+
+use crate::llvm::Compile;
+
+// The start component of a module declares the function index of a start function that is automatically invoked
+// when the module is instantiated, after tables and memories have been initialized.
+// https://webassembly.github.io/spec/core/syntax/modules.html#start-function
+
+pub const START_INSTRUCTION: &str = "awsm_abi__start_fn";
+
+pub fn generate_start_stub(ctx: &ModuleCtx, start_fn_idx: Option<u32>) {
+    if let Some(idx) = start_fn_idx {
+        let (_, func) = &ctx.functions[idx as usize];
+
+        match func {
+            Implemented { f } => {
+                if let Some(start_function_type) = &f.ty {
+                    if start_function_type.params.len() > 0 {
+                        panic!("Expected start function to not take parameters");
+                    }
+                } else {
+                    panic!("Expected start function to have type");
+                }
+
+                let setup_function = ctx.llvm_module.add_function(
+                    START_INSTRUCTION,
+                    FunctionType::new(<()>::get_type(ctx.llvm_ctx), &[]).to_super(),
+                );
+                let bb = setup_function.append("entry");
+                let b = Builder::new(ctx.llvm_ctx);
+                b.position_at_end(bb);
+                b.build_call(
+                    ctx.llvm_module.get_function(&f.generated_name).unwrap(),
+                    &[],
+                );
+
+                b.build_ret_void();
+            }
+            _ => {
+                panic!("Expected start function to be locally implemented");
+            }
+        }
+    } else {
+        let setup_function = ctx.llvm_module.add_function(
+            START_INSTRUCTION,
+            FunctionType::new(<()>::get_type(ctx.llvm_ctx), &[]).to_super(),
+        );
+        let bb = setup_function.append("entry");
+        let b = Builder::new(ctx.llvm_ctx);
+        b.position_at_end(bb);
+        b.build_ret_void();
+    }
+}


### PR DESCRIPTION
This PR implements the `(start)` instruction, which registers a function to run during execution. It takes a function index as follows:

```wasm
(start 2)
````

which generates a call as follows

```llvm
define void @awsm_abi__start_fn() {
entry:
  call void @wasmf_internal_2()
  ret void
}
```

When the start instruction isn't called, the compiler generates a NOP function:

```llvm
define void @awsm_abi__start_fn() {
entry:
  ret void
}
```

Here is the test module in `wasm_apps` I'm using, which is not in this diff:
```wasm
(module
	(global $counter (mut i32) (i32.const 0))

	(func (export "increment") (result i32)
		(global.set $counter (i32.add (global.get $counter) (i32.const 1)))
		(global.get $counter)
	)

	(func $init
		(global.set $counter (i32.const 42))
	)

	(start $init)
	
)
```

The is used in this test, which now runs successfully:
```c
#include "../../runtime/runtime.h"

IMPORT int wasmf_increment(void);

int main(int argc, char* argv[]) {
    runtime_init();

    awsm_assert(wasmf_increment() == 43);
    awsm_assert(wasmf_increment() == 44);
}
```

The first invocation of `wasmf_increment()` returns 1 when I comment out the `(start $init)` instruction because the generated `awsm_abi__start_fn` doesn't call `wasmf_internal_2()`