### PR TITLE
Cleanup llvm versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,9 +7,11 @@ env:
   RUSTFLAGS: --deny warnings
   # used during LLVM installation
   LLVM_VERSION: 12
+  WASI_SDK_VERSION: 12
+  CLANG_FORMAT_VERSION: 13
   # URLs for WebAssembly libcs
   WASMCEPTION_URL: https://github.com/gwsystems/wasmception/releases/download/v0.2.0/wasmception-linux-x86_64-0.2.0.tar.gz
-  WASI_SDK_URL: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
+  WASI_SDK_URL: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_SDK_VERSION/wasi-sdk-$WASI_SDK_VERSION.0-linux.tar.gz
   LIBUV_URL: https://github.com/libuv/libuv/archive/refs/tags/v1.42.0.tar.gz
   UVWASI_URL: https://github.com/nodejs/uvwasi/archive/refs/tags/v0.0.11.tar.gz
   # Used by Makefiles that compile *.c to *.wasm
@@ -23,8 +25,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Clang Format
         run: |
-          sudo apt install clang-format-12 --yes
-          find runtime example_code -type f -print | grep -v runtime/libuv | grep -v runtime/uvwasi | grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-12 -Werror -n -ferror-limit=0
+          sudo apt install clang-format-$CLANG_FORMAT_VERSION --yes
+          find runtime example_code -type f -print | grep -v runtime/libuv | grep -v runtime/uvwasi | grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-$CLANG_FORMAT_VERSION -Werror -n -ferror-limit=0
       - name: Cargo Format
         run: cargo fmt -- --check
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,8 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Clang Format
         run: |
-          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-$CLANG_FORMAT_VERSION main"
-          sudo apt update
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-$CLANG_FORMAT_VERSION main"
           sudo apt update
           sudo apt install clang-format-$CLANG_FORMAT_VERSION --yes

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,8 +10,6 @@ env:
   WASI_SDK_VERSION: 12
   CLANG_FORMAT_VERSION: 13
   # URLs for WebAssembly libcs
-  WASMCEPTION_URL: https://github.com/gwsystems/wasmception/releases/download/v0.2.0/wasmception-linux-x86_64-0.2.0.tar.gz
-  WASI_SDK_URL: https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_SDK_VERSION/wasi-sdk-$WASI_SDK_VERSION.0-linux.tar.gz
   LIBUV_URL: https://github.com/libuv/libuv/archive/refs/tags/v1.42.0.tar.gz
   UVWASI_URL: https://github.com/nodejs/uvwasi/archive/refs/tags/v0.0.11.tar.gz
   # Used by Makefiles that compile *.c to *.wasm
@@ -25,6 +23,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Clang Format
         run: |
+          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-$CLANG_FORMAT_VERSION main"
+          sudo apt update
           sudo apt install clang-format-$CLANG_FORMAT_VERSION --yes
           find runtime example_code -type f -print | grep -v runtime/libuv | grep -v runtime/uvwasi | grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-$CLANG_FORMAT_VERSION -Werror -n -ferror-limit=0
       - name: Cargo Format
@@ -54,6 +54,7 @@ jobs:
       - name: Get wasmception
         if: matrix.libc == 'wasmception'
         run: |
+          WASMCEPTION_URL=https://github.com/gwsystems/wasmception/releases/download/v0.2.0/wasmception-linux-x86_64-0.2.0.tar.gz
           wget $WASMCEPTION_URL -O wasmception.tar.gz
           mkdir -p wasmception
           tar xvfz wasmception.tar.gz -C wasmception
@@ -61,6 +62,7 @@ jobs:
       - name: Get wasi-sdk
         if: matrix.libc == 'wasi-sdk'
         run: |
+          WASI_SDK_URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_SDK_VERSION/wasi-sdk-$WASI_SDK_VERSION.0-linux.tar.gz
           wget $WASI_SDK_URL -O wasi-sdk.tar.gz
           mkdir -p /opt/wasi-sdk
           tar xvfz wasi-sdk.tar.gz --strip-components=1 -C /opt/wasi-sdk

--- a/applications/Makefile
+++ b/applications/Makefile
@@ -1,6 +1,7 @@
 AWSMCC=../target/release/awsm
 CC=clang
 ARCH=64bit_nix
+LLVM_VERSION=12
 
 # Used by aWsm when compiling the *.wasm to *.bc
 # No need for adding the --runtime-globals flag for just a single sandbox exec
@@ -39,7 +40,7 @@ dist/%.bc: ./wasm_apps/dist/%.wasm dist
 	${AWSMCC} ${AWSMFLAGS} $< -o $@
 
 dist/%.ll: dist/%.bc
-	llvm-dis-12 $< -o $@
+	llvm-dis-${LLVM_VERSION} $< -o $@
 
 # By default choose the bc.mini.awsm mode:
 dist/%.awsm: dist/%.bc.mini.awsm ;

--- a/code_benches/app_tinycrypt/Makefile
+++ b/code_benches/app_tinycrypt/Makefile
@@ -1,5 +1,6 @@
 CC=clang
 OPTFLAGS=-O3 -flto
+LLVM_VERSION=12
 
 # Assuming to be called from code_benches/app_tinycrypt directory
 ROOT_PATH:=$(shell cd ../.. && realpath .)
@@ -77,7 +78,7 @@ bin/app_tinycrypt_us.bc: bin/app_tinycrypt.wasm
 	@${AWSM_CC} -u $^ -o $@
 
 %.ll: %.bc
-	llvm-dis-12 $^ -o $@
+	llvm-dis-${LLVM_VERSION} $^ -o $@
 
 # Run unsafe code using the "No Protection" memory model
 bin/app_tinycrypt_np_us: bin/app_tinycrypt_us.bc ${RUNTIME_NP}

--- a/code_benches/custom_binarytrees/Makefile
+++ b/code_benches/custom_binarytrees/Makefile
@@ -1,5 +1,6 @@
 CC=clang
 OPTFLAGS=-O3 -flto
+LLVM_VERSION=12
 
 # Assuming to be called from code_benches/custom_binarytrees directory
 ROOT_PATH:=$(shell cd ../.. && realpath .)
@@ -77,7 +78,7 @@ bin/custom_binarytrees_us.bc: bin/custom_binarytrees.wasm
 	@${AWSM_CC} -u $^ -o $@
 
 %.ll: %.bc
-	llvm-dis-12 $^ -o $@
+	llvm-dis-${LLVM_VERSION} $^ -o $@
 
 # Run unsafe code using the "No Protection" memory model
 bin/custom_binarytrees_np_us: bin/custom_binarytrees_us.bc ${RUNTIME_NP}

--- a/code_benches/run.py
+++ b/code_benches/run.py
@@ -33,6 +33,8 @@ args = parser.parse_args()
 assert not (args.debug and args.release), "Both --debug and --release provided"
 assert not (args.wasi_sdk and args.wasmception), "Both --wask-sdk and --wasmception provided"
 
+WASI_SDK_VERSION = 12
+
 # Note: This is a major configuration option, you probably want to set this if you're doing anything non-trivial
 AWSM_TARGET = args.target
 # AWSM_TARGET = "thumbv7em-none-unknown-eabi"
@@ -97,9 +99,9 @@ WASI_SDK_LINKER_FLAGS = "-Wl,--allow-undefined,-z,stack-size={stack_size},--thre
 
 # download WASI-SDK if it is not in the expected path
 if sys.platform == "linux" or sys.platform == "linux2":
-    WASI_SDK_URL = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz"
+    WASI_SDK_URL = f"https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{WASI_SDK_VERSION}/wasi-sdk-{WASI_SDK_VERSION}.0-linux.tar.gz"
 elif sys.platform == "darwin":
-    WASI_SDK_URL = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-macos.tar.gz"
+    WASI_SDK_URL = f"https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-{WASI_SDK_VERSION}/wasi-sdk-{WASI_SDK_VERSION}.0-macos.tar.gz"
 else:
     print("awsm supports Linux and Mac OS, saw {}".format(sys.platform))
     exit(1)

--- a/format.sh
+++ b/format.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CLANG_FORMAT_VERSION=13 # This is a better version for formatting
+
 utility="clang-format"
 utility_version="$("$utility" --version 2>/dev/null)" || {
 	echo "$utility not found in path!"
@@ -10,7 +12,7 @@ regex="version ([0-9]+).([0-9]+).([0-9]+)"
 declare -i major=0
 declare -i minor=0
 declare -i patch=0
-declare -i required_major=9
+declare -i required_major=$CLANG_FORMAT_VERSION
 declare -i required_minor=0
 declare -i required_patch=0
 
@@ -32,6 +34,6 @@ fi
 find runtime example_code -type f -print |
 	grep -v runtime/libuv |
 	grep -v runtime/uvwasi |
-	grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-12 -i
+	grep --exclude-dir -i -E '^*.(c|h|ld|s)$' | xargs clang-format-$CLANG_FORMAT_VERSION -i
 
 cargo fmt

--- a/install_deb.sh
+++ b/install_deb.sh
@@ -25,8 +25,14 @@ $sudo apt install lsb-release wget software-properties-common --yes
 $sudo apt install wabt --yes
 
 # Install LLVM build dependencies
+# Note, wasi-sdk versions do NOT match llvm versions, e.g. wasi-sdk-12 actually uses llvm-11 
 LLVM_VERSION=12
+WASI_SDK_VERSION=12
+CLANG_FORMAT_VERSION=13 # This is a better version for formatting
 $sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)" bash $LLVM_VERSION
+
+$sudo apt install libc++-$LLVM_VERSION-dev libc++abi-$LLVM_VERSION-dev --yes
+$sudo apt install "clang-format-$CLANG_FORMAT_VERSION" --yes
 
 $sudo update-alternatives --remove-all clang
 $sudo update-alternatives --remove-all clang++
@@ -34,7 +40,7 @@ $sudo update-alternatives --remove-all llvm-config
 $sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$LLVM_VERSION 100
 $sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$LLVM_VERSION 100
 $sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-$LLVM_VERSION 100
-$sudo apt install libc++-11-dev libc++abi-11-dev --yes
+$sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$CLANG_FORMAT_VERSION 100
 
 # Install Binaryen
 # Clang uses Binaryen's wasm-opt utility to optimize WebAssembly
@@ -65,10 +71,10 @@ cd .. || exit
 if [[ -n "${WASI_SDK_PATH}" ]] && [[ -x "${WASI_SDK_PATH}/bin/clang" ]]; then
 	echo "wasi-sdk detected"
 else
-	wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk_12.0_amd64.deb
-	# The Debian package installs WASI-SDK 12 to /opt/wasi-sdk
-	$sudo dpkg -i wasi-sdk_12.0_amd64.deb
-	rm -f wasi-sdk_12.0_amd64.deb
+	wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$WASI_SDK_VERSION/wasi-$WASI_SDK_VERSION.0_amd64.deb
+	# The Debian package installs WASI-SDK to /opt/wasi-sdk
+	$sudo dpkg -i wasi-sdk_$WASI_SDK_VERSION.0_amd64.deb
+	rm -f wasi-sdk_$WASI_SDK_VERSION.0_amd64.deb
 	echo 'export WASI_SDK_PATH="/opt/wasi-sdk/"' >> ~/.bashrc
 	source ~/.bashrc
 fi

--- a/runtime/cortex_m_glue/printf.c
+++ b/runtime/cortex_m_glue/printf.c
@@ -732,8 +732,8 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
 #if defined(PRINTF_SUPPORT_LONG_LONG)
                         const long long value = va_arg(va, long long);
                         idx                   = _ntoa_long_long(out, buffer, idx, maxlen,
-                                              (unsigned long long)(value > 0 ? value : 0 - value), value < 0, base,
-                                              precision, width, flags);
+                                                                (unsigned long long)(value > 0 ? value : 0 - value), value < 0, base,
+                                                                precision, width, flags);
 #endif
                     } else if (flags & FLAGS_LONG) {
                         const long value = va_arg(va, long);

--- a/runtime/libc/wasi/include/wasi_backing.h
+++ b/runtime/libc/wasi/include/wasi_backing.h
@@ -48,7 +48,7 @@ uint32_t wasi_snapshot_preview1_args_get(__wasi_size_t argv_retoffset, __wasi_si
     }
 
     __wasi_size_t*      argv_retptr     = (__wasi_size_t*)get_memory_ptr_for_runtime(argv_retoffset,
-                                                                            WASI_SERDES_SIZE_size_t * argc);
+                                                                                     WASI_SERDES_SIZE_size_t * argc);
     const __wasi_size_t argv_buf_size   = wasi_context_get_argv_buf_size(CURRENT_WASI_CONTEXT);
     char*               argv_buf_retptr = get_memory_ptr_for_runtime(argv_buf_retoffset, argv_buf_size);
 
@@ -158,7 +158,7 @@ uint32_t wasi_snapshot_preview1_environ_get(__wasi_size_t env_retoffset, __wasi_
     }
 
     __wasi_size_t* env_retptr     = (__wasi_size_t*)get_memory_ptr_for_runtime(env_retoffset,
-                                                                           WASI_SERDES_SIZE_size_t * envc);
+                                                                               WASI_SERDES_SIZE_size_t * envc);
     char*          env_buf_retptr = get_memory_ptr_for_runtime(env_buf_retoffset, env_buf_size);
 
     rc = wasi_snapshot_preview1_backing_environ_get(CURRENT_WASI_CONTEXT, env_temp, env_buf_retptr);
@@ -894,10 +894,10 @@ uint32_t wasi_snapshot_preview1_poll_oneoff(__wasi_size_t in_baseoffset, __wasi_
     const __wasi_subscription_t* in_baseptr = (const __wasi_subscription_t*)
       get_memory_ptr_for_runtime(in_baseoffset, WASI_SERDES_SIZE_subscription_t * nsubscriptions);
     __wasi_event_t* out_baseptr    = (__wasi_event_t*)get_memory_ptr_for_runtime(out_baseoffset,
-                                                                              WASI_SERDES_SIZE_subscription_t
-                                                                                * nsubscriptions);
+                                                                                 WASI_SERDES_SIZE_subscription_t
+                                                                                   * nsubscriptions);
     __wasi_size_t*  nevents_retptr = (__wasi_size_t*)get_memory_ptr_for_runtime(nevents_retoffset,
-                                                                               WASI_SERDES_SIZE_size_t);
+                                                                                WASI_SERDES_SIZE_size_t);
 
     return (uint32_t)wasi_snapshot_preview1_backing_poll_oneoff(CURRENT_WASI_CONTEXT, in_baseptr, out_baseptr,
                                                                 nsubscriptions, nevents_retptr);

--- a/tests/wasi/Makefile
+++ b/tests/wasi/Makefile
@@ -7,7 +7,7 @@ ARCH=64bit_nix
 # RUNTIME_CFLAGS += -DLOG_WASI
 
 
-# program.c => wasi-sdk-12 => program.wasm => aWsm => program.bc => clang => program (runtime baked in)
+# program.c => wasi-sdk => program.wasm => aWsm => program.bc => clang => program (runtime baked in)
 
 OBJ = $(patsubst c/%.c, vm/%_vm, $(wildcard c/*.c))
 all: ${OBJ}

--- a/tests/wat/Makefile
+++ b/tests/wat/Makefile
@@ -1,6 +1,7 @@
 ROOT_PATH:=$(shell cd ../.. && realpath .)
 RUNTIME_PATH:=${ROOT_PATH}/runtime
 ARCH=64bit_nix
+LLVM_VERSION=12
 
 CC=clang
 OPTFLAGS=-O0 -g -flto
@@ -69,7 +70,7 @@ clean:
 	@RUST_BACKTRACE=1 ${AWSM_CC} $< -o $@ 1>$*.log 2>&1
 
 %.ll: %.bc
-	@llvm-dis-12 $< -o $@
+	@llvm-dis-${LLVM_VERSION} $< -o $@
 
 .PHONY: %_wasmtime
 %_wasmtime: %.wasm


### PR DESCRIPTION
With this PR the mismatch among the LLVM, WASI_SDK and CLANG-FORMAT versions in awsm and sledge repos is fixed. 

Here are the latest versions:

```
LLVM= 12
WASI_SDK = 12
CLANG_FORMAT = 13
```

P.S. Apparently wasi-sdk versions do NOT match llvm versions, e.g. `wasi-sdk-12` actually uses `llvm-11`. There is actual wasi-sdk version that uses LLVM_VERSION=12. 